### PR TITLE
Passing all deps through latest-version lib and including requested version.

### DIFF
--- a/lib/new.js
+++ b/lib/new.js
@@ -150,7 +150,6 @@ async function updatePackageDependencies() {
 
   await setDependencyVersions(packageJson.dependencies);
   await setDependencyVersions(packageJson.devDependencies);
-  await setDependencyVersions(packageJson.peerDependencies);
 
   await fs.writeJson(
     packagePath,

--- a/lib/new.js
+++ b/lib/new.js
@@ -102,18 +102,15 @@ function cleanupTemplate() {
 }
 
 /**
- * Finds all dependencies with a version specified as "latest", looks up the package in the global
- * NPM registry, and replaces it with the actual version number of the latest version of the package.
+ * Pass each dependency and it's requested version through the `install-latest` library.
+ * This supports any valid semver version, but will resolve to the exact version.
  * @param {*} dependencies The dependencies with versions to resolve.
  */
 async function setDependencyVersions(dependencies) {
   const packageNames = Object.keys(dependencies);
 
   const dependencyPromises = packageNames.map(
-    packageName => dependencies[packageName] === 'latest' ?
-      latestVersion(packageName) :
-      // Default to the specified version.
-      Promise.resolve(dependencies[packageName])
+    packageName => latestVersion(packageName, { version: dependencies[packageName] })
   );
 
   const versionNumbers = await Promise.all(dependencyPromises);

--- a/test/lib-new.spec.js
+++ b/test/lib-new.spec.js
@@ -64,8 +64,8 @@ describe('skyux new command', () => {
     });
 
     versionsRequested = {};
-    mock('latest-version', (dep) => {
-      versionsRequested[dep] = true;
+    mock('latest-version', (dep, options) => {
+      versionsRequested[dep] = options;
       return Promise.resolve(`${dep}-LATEST`);
     });
 
@@ -453,7 +453,7 @@ describe('skyux new command', () => {
     });
   });
 
-  it('should update package dependencies to the latest version', (done) => {
+  it('should update package dependencies', (done) => {
     const spy = spyOn(mockFs, 'writeJson').and.callThrough();
 
     spyOn(mockFs, 'readJsonSync').and.returnValue({
@@ -483,9 +483,9 @@ describe('skyux new command', () => {
           expect(spy).toHaveBeenCalledWith(
             `skyux-spa-${spaName}/tmp/package.json`,
             {
-              dependencies: { foo: 'foo-LATEST', bar: '1.0.0' },
-              peerDependencies: { foo: 'foo-LATEST', bar: '1.0.0' },
-              devDependencies: { foo: 'foo-LATEST', bar: '1.0.0' },
+              dependencies: { foo: 'foo-LATEST', bar: 'bar-LATEST' },
+              peerDependencies: { foo: 'foo-LATEST', bar: 'bar-LATEST' },
+              devDependencies: { foo: 'foo-LATEST', bar: 'bar-LATEST' },
               name: `blackbaud-skyux-spa-${spaName}`,
               description: `Single-page-application (SPA) for skyux-spa-${spaName}`,
               repository: {
@@ -495,7 +495,8 @@ describe('skyux new command', () => {
             },
             { spaces: 2 }
           );
-          expect(versionsRequested['foo']).toEqual(true);
+          expect(versionsRequested['foo']).toEqual({ version: 'latest' });
+          expect(versionsRequested['bar']).toEqual({ version: '1.0.0' });
           done();
         });
       });

--- a/test/lib-new.spec.js
+++ b/test/lib-new.spec.js
@@ -453,7 +453,7 @@ describe('skyux new command', () => {
     });
   });
 
-  it('should update package dependencies', (done) => {
+  it('should update package dependencies & devDeps but not peerDeps', (done) => {
     const spy = spyOn(mockFs, 'writeJson').and.callThrough();
 
     spyOn(mockFs, 'readJsonSync').and.returnValue({
@@ -484,7 +484,7 @@ describe('skyux new command', () => {
             `skyux-spa-${spaName}/tmp/package.json`,
             {
               dependencies: { foo: 'foo-LATEST', bar: 'bar-LATEST' },
-              peerDependencies: { foo: 'foo-LATEST', bar: 'bar-LATEST' },
+              peerDependencies: { foo: 'latest', bar: '1.0.0' },
               devDependencies: { foo: 'foo-LATEST', bar: 'bar-LATEST' },
               name: `blackbaud-skyux-spa-${spaName}`,
               description: `Single-page-application (SPA) for skyux-spa-${spaName}`,


### PR DESCRIPTION
Fixes #18.
To be used in conjunction (but not required) with:
- https://github.com/blackbaud/skyux-sdk-template/pull/3
- https://github.com/blackbaud/skyux-sdk-template-library/pull/2