### PR TITLE
Trust linux remove argv

### DIFF
--- a/index.js
+++ b/index.js
@@ -180,15 +180,18 @@ function processArgv(argv) {
 
   logger.info(`SKY UX is processing the '${command}' command.`);
 
-  // sslCert and sslKey are required by builder
-  argv.sslCert = certUtils.getCertPath(argv);
-  argv.sslKey = certUtils.getKeyPath(argv);
+  // Don't validate custom sslCert and sslKey
+  if (!argv.sslCert && !argv.sslKey) {
 
-  // Validate cert for specific scenarios
-  if (!validateCert(command, argv)) {
-    logger.warn(`Unable to validate ${argv.sslCert} and ${argv.sslKey}.`);
-    logger.warn(`You may proceed, but \`skyux ${command}\` may not function properly.`)
-    logger.warn('Please install the latest SKY UX CLI and run `skyux certs install`.');
+    argv.sslCert = certUtils.getCertPath();
+    argv.sslKey = certUtils.getKeyPath();
+
+    // Validate cert for specific scenarios
+    if (!validateCert(command, argv)) {
+      logger.warn(`Unable to validate ${argv.sslCert} and ${argv.sslKey}.`);
+      logger.warn(`You may proceed, but \`skyux ${command}\` may not function properly.`)
+      logger.warn('Please install the latest SKY UX CLI and run `skyux certs install`.');
+    }
   }
 
   switch (command) {

--- a/lib/certs.js
+++ b/lib/certs.js
@@ -9,6 +9,14 @@ function formatArgumentList(args) {
   return args.map(arg => `"${arg}"`).join();
 }
 
+function logAutomationStart(action, level) {
+  logger.info(`Automatically trying to ${action} the SKY UX certificate at the ${level} level.`);
+}
+
+function logAutomationError(err) {
+  logger.error(`Unsuccessful in completing last task: ${err}`);
+}
+
 async function trust(argv) {
   logger.info('Trusting SKY UX certificate.');
   switch (os.type()) {
@@ -47,20 +55,55 @@ async function untrust(argv) {
 }
 
 async function trustLinux() {
-  await spawn(`sudo`, `cp`, certUtils.getCertPath(), `/usr/local/share/ca-certificates/${certUtils.getCertName()}`);
-  await spawn(`sudo`, `update-ca-certificates`);
+  try {
+    logAutomationStart('trust', 'OS');
+    await spawn(`sudo`, `cp`, certUtils.getCertPath(), `/usr/local/share/ca-certificates/${certUtils.getCertName()}`);
+    await spawn(`sudo`, `update-ca-certificates`);
+  } catch (err) {
+    logAutomationError(err);
+  }
+
+  try {
+    logAutomationStart('trust', 'NSS Chrome');
+    await spawn(`certutil`, `-d`, `sql:${os.homedir()}/.pki/nssdb`, `-A`, `-t`, `P`, `-n`, certUtils.getCertCommonName(), `-i`, certUtils.getCertPath());
+  } catch (err) {
+    logAutomationError(err);
+  }
 }
 
 async function untrustLinux() {
-  await spawn(`sudo`, `update-ca-certificates`, `--fresh`);
+  try {
+    logAutomationStart('untrust', 'OS');
+    await spawn(`sudo`, `rm`, `-rf`, `/usr/local/share/ca-certificates/${certUtils.getCertName()}`);
+    await spawn(`sudo`, `update-ca-certificates`, `--fresh`);    
+  } catch (err) {
+    logAutomationError( err);
+  }
+
+  try {
+    logAutomationStart('untrust', 'NSS Chrome');
+    await spawn(`certutil`, `-D`, `-d`, `sql:${os.homedir()}/.pki/nssdb`,`-n`, certUtils.getCertCommonName());
+  } catch (err) {
+    logAutomationError(err);
+  }
 }
 
 async function trustMac() {
-  await spawn(`sudo`, `security`, `add-trusted-cert`, `-d`, `-r`, `trustRoot`, `-k`, `/Library/Keychains/System.keychain`, certUtils.getCertPath());
+  try {
+    logAutomationStart('trust', 'OS');
+    await spawn(`sudo`, `security`, `add-trusted-cert`, `-d`, `-r`, `trustRoot`, `-k`, `/Library/Keychains/System.keychain`, certUtils.getCertPath());
+  } catch (err) {
+    logAutomationError(err);
+  }
 }
 
 async function untrustMac() {
-  await spawn(`sudo`, `security`, `delete-certificate`, `-c`, certUtils.getCertCommonName());
+  try {
+    logAutomationStart('untrust', 'OS');
+    await spawn(`sudo`, `security`, `delete-certificate`, `-c`, certUtils.getCertCommonName());
+  } catch (err) {
+    logAutomationError(err);
+  }
 }
 
 async function trustWindows(argv) {
@@ -71,7 +114,12 @@ async function trustWindows(argv) {
     cmdArgs.push('&', 'PAUSE');
   }
 
-  await spawn(`powershell`, `start-process cmd -verb runas -ArgumentList @(${formatArgumentList(cmdArgs)})`);
+  try {
+    logAutomationStart('trust', 'OS');
+    await spawn(`powershell`, `start-process cmd -verb runas -ArgumentList @(${formatArgumentList(cmdArgs)})`);
+  } catch (err) {
+    logAutomationError(err);
+  }
 }
 
 async function untrustWindows(argv) {
@@ -82,51 +130,57 @@ async function untrustWindows(argv) {
     cmdArgs.push('&', 'PAUSE');
   }
 
-  await spawn(`powershell`, `start-process cmd -verb runas -ArgumentList @(${formatArgumentList(cmdArgs)})`);
+  try {
+    logAutomationStart('untrust', 'OS');
+    await spawn(`powershell`, `start-process cmd -verb runas -ArgumentList @(${formatArgumentList(cmdArgs)})`);
+  } catch (err) {
+    logAutomationError(err);
+  }
 }
 
 async function install(argv) {
-  certUtils.generate();
-  await trust(argv);
+  try {
+    logger.info('Attempting to install SKY UX certificate.');
+    certUtils.generate();
+    await trust(argv);
+  } catch (err) {
+    logger.error(`Unable to install the SKY UX certificate.`);
+  }
 }
 
 async function uninstall(argv) {
-  certUtils.remove();
-  await untrust(argv);
+  try {
+    logger.info('Attempting to uninstall the SKY UX certificate.');
+    certUtils.remove();
+    await untrust(argv);
+  } catch (err) {
+    logger.error(`Unable to uninstall the SKY UX certificate.`);
+  }
 }
 
 module.exports = async function certs(argv) {
-  try {
-    switch (argv['_'][1]) {
-      case 'generate':
-        certUtils.generate();
-      break;
+  switch (argv['_'][1]) {
+    case 'generate':
+      certUtils.generate();
+    break;
 
-      case 'install':
+    case 'install':
+      await uninstall(argv);
+      await install(argv);
+    break;
 
-        try {
-          await uninstall(argv);
-        } catch (ignoreErr) {
-          logger.verbose('Ignoring uninstall error.');
-        }
+    case 'uninstall':
+      await uninstall(argv);
+    break;
 
-        await install(argv);
-      break;
+    case 'validate':
+      logger.info('Validating SKY UX certificate and key.');
+      certUtils.validate();
+    break;
 
-      case 'uninstall':
-        await uninstall(argv);
-      break;
-
-      case 'validate':
-        certUtils.validate();
-      break;
-
-      default:
-        logger.warn(`Unknown action for the certs command.`);
-        logger.warn(`Available actions are install and uninstall.`)
-      break;
-    }
-  } catch (err) {
-    logger.error(`Command exited with error: ${err}`);
+    default:
+      logger.warn(`Unknown action for the certs command.`);
+      logger.warn(`Available actions are install and uninstall.`)
+    break;
   }
 };

--- a/lib/certs.js
+++ b/lib/certs.js
@@ -13,10 +13,10 @@ async function trust(argv) {
   logger.info('Trusting SKY UX certificate.');
   switch (os.type()) {
     case 'Darwin':
-      await trustMac(argv);
+      await trustMac();
     break;
     case 'Linux':
-      await trustLinux(argv);
+      await trustLinux();
     break;
     case 'Windows_NT':
       await trustWindows(argv);
@@ -46,8 +46,8 @@ async function untrust(argv) {
   logger.info('Successfully untrusted SKY UX certificate.');
 }
 
-async function trustLinux(argv) {
-  await spawn(`sudo`, `cp`, certUtils.getCertPath(argv), `/usr/local/share/ca-certificates/${certUtils.getCertName()}`);
+async function trustLinux() {
+  await spawn(`sudo`, `cp`, certUtils.getCertPath(), `/usr/local/share/ca-certificates/${certUtils.getCertName()}`);
   await spawn(`sudo`, `update-ca-certificates`);
 }
 
@@ -55,16 +55,16 @@ async function untrustLinux() {
   await spawn(`sudo`, `update-ca-certificates`, `--fresh`);
 }
 
-async function trustMac(argv) {
-  await spawn(`sudo`, `security`, `add-trusted-cert`, `-d`, `-r`, `trustRoot`, `-k`, `/Library/Keychains/System.keychain`, certUtils.getCertPath(argv));
+async function trustMac() {
+  await spawn(`sudo`, `security`, `add-trusted-cert`, `-d`, `-r`, `trustRoot`, `-k`, `/Library/Keychains/System.keychain`, certUtils.getCertPath());
 }
 
 async function untrustMac() {
-  await spawn(`sudo`, `security`, `delete-certificate`, `-c`, certUtils.getCertName());
+  await spawn(`sudo`, `security`, `delete-certificate`, `-c`, certUtils.getCertCommonName());
 }
 
 async function trustWindows(argv) {
-  const cmdArgs = ['/c', 'certutil', '-addstore', '-f', 'root', certUtils.getCertPath(argv)];
+  const cmdArgs = ['/c', 'certutil', '-addstore', '-f', 'root', certUtils.getCertPath()];
 
   // Pauses by default.
   if (argv.pause !== false) {
@@ -75,7 +75,7 @@ async function trustWindows(argv) {
 }
 
 async function untrustWindows(argv) {
-  const cmdArgs = ['/c', 'certutil', '-delstore', 'root', certUtils.getCertName()];
+  const cmdArgs = ['/c', 'certutil', '-delstore', 'root', certUtils.getCertCommonName()];
 
   // Pauses by default.
   if (argv.pause !== false) {
@@ -89,21 +89,21 @@ module.exports = async function certs(argv) {
   try {
     switch (argv['_'][1]) {
       case 'generate':
-        certUtils.generate(argv);
+        certUtils.generate();
       break;
 
       case 'install':
-        certUtils.generate(argv);
+        certUtils.generate();
         await trust(argv);
       break;
 
       case 'uninstall':
-        certUtils.remove(argv);
+        certUtils.remove();
         await untrust(argv);
       break;
 
       case 'validate':
-        certUtils.validate(argv);
+        certUtils.validate();
       break;
 
       default:

--- a/lib/certs.js
+++ b/lib/certs.js
@@ -85,6 +85,16 @@ async function untrustWindows(argv) {
   await spawn(`powershell`, `start-process cmd -verb runas -ArgumentList @(${formatArgumentList(cmdArgs)})`);
 }
 
+async function install(argv) {
+  certUtils.generate();
+  await trust(argv);
+}
+
+async function uninstall(argv) {
+  certUtils.remove();
+  await untrust(argv);
+}
+
 module.exports = async function certs(argv) {
   try {
     switch (argv['_'][1]) {
@@ -93,13 +103,12 @@ module.exports = async function certs(argv) {
       break;
 
       case 'install':
-        certUtils.generate();
-        await trust(argv);
+        await uninstall(argv);
+        await install(argv);
       break;
 
       case 'uninstall':
-        certUtils.remove();
-        await untrust(argv);
+        await uninstall(argv);
       break;
 
       case 'validate':

--- a/lib/certs.js
+++ b/lib/certs.js
@@ -103,7 +103,13 @@ module.exports = async function certs(argv) {
       break;
 
       case 'install':
-        await uninstall(argv);
+
+        try {
+          await uninstall(argv);
+        } catch (ignoreErr) {
+          logger.verbose('Ignoring uninstall error.');
+        }
+
         await install(argv);
       break;
 

--- a/lib/certs.js
+++ b/lib/certs.js
@@ -165,7 +165,9 @@ module.exports = async function certs(argv) {
     break;
 
     case 'install':
-      await uninstall(argv);
+      if (certUtils.validate()) {
+        await uninstall(argv);
+      }
       await install(argv);
     break;
 

--- a/lib/utils/cert-utils.js
+++ b/lib/utils/cert-utils.js
@@ -43,7 +43,7 @@ function generate() {
   const certificate = forge.pki.createCertificate();
   const attrs = [{
     name: 'commonName',
-    value: getCertCommonName()
+    value: 'localhost'
   }];
 
   certificate.publicKey = keys.publicKey;

--- a/lib/utils/cert-utils.js
+++ b/lib/utils/cert-utils.js
@@ -5,21 +5,24 @@ const forge = require('node-forge');
 const logger = require('@blackbaud/skyux-logger');
 
 const certCommonName = 'SKYUX-Developer-Certificate';
-const certName = 'skyux-server.pem';
+const certName = 'skyux-server.crt';
 const keyName = 'skyux-server.key';
 
-const defaultCertRootPath = path.resolve(`${os.homedir()}/.skyux/certs/`);
-const defaultCertPath = path.join(defaultCertRootPath, certName);
-const defaultKeyPath = path.join(defaultCertRootPath, keyName);
+const defaultCertDir = path.resolve(`${os.homedir()}/.skyux/certs/`);
+const defaultCertPath = path.join(defaultCertDir, certName);
+const defaultKeyPath = path.join(defaultCertDir, keyName);
+
+// The methods provided in this class purposefully do not allow argv overrides.
+// These commands only deal with known filenames and locations.
 
 function error(msg) {
   logger.error(msg);
   return false;
 }
 
-function validate(argv) {
-  const cert = getCertPath(argv);
-  const key = getKeyPath(argv);
+function validate() {
+  const cert = getCertPath();
+  const key = getKeyPath();
 
   if (!fs.existsSync(cert)) {
     return error(`Error locating certificate: ${cert}`);
@@ -29,18 +32,18 @@ function validate(argv) {
     return error(`Error locating key: ${key}`);
   }
 
-  // TODO: VALIDATE CERT + KEY using forge
+  // https://github.com/blackbaud/skyux-sdk-cli/issues/37
   return true;
 }
 
-function generate(argv) {
+function generate() {
   logger.info('Generating SKY UX certificate.');
   const now = new Date();
   const keys = forge.pki.rsa.generateKeyPair(2048);
   const certificate = forge.pki.createCertificate();
   const attrs = [{
     name: 'commonName',
-    value: getCertName()
+    value: getCertCommonName()
   }];
 
   certificate.publicKey = keys.publicKey;
@@ -67,41 +70,47 @@ function generate(argv) {
       serverAuth: true
     }, {
       name: 'friendlyName',
-      value: getCertName()
+      value: getCertCommonName()
     }]);
 
   certificate.sign(keys.privateKey, forge.md.sha256.create());
 
-  // Ensure parent directories exist
-  fs.ensureDirSync(path.dirname(getCertPath(argv)));
-  fs.ensureDirSync(path.dirname(getKeyPath(argv)));
+  fs.ensureDirSync(defaultCertDir);
+  fs.writeFileSync(getCertPath(), forge.pki.certificateToPem(certificate));
+  fs.writeFileSync(getKeyPath(), forge.pki.privateKeyToPem(keys.privateKey));
 
-  fs.writeFileSync(getCertPath(argv), forge.pki.certificateToPem(certificate));
-  fs.writeFileSync(getKeyPath(argv), forge.pki.privateKeyToPem(keys.privateKey));
-
-  logger.info(`Successfully generated ${getCertPath(argv)} and ${getKeyPath(argv)}.`);
+  logger.info(`Successfully generated ${getCertPath()} and ${getKeyPath()}.`);
 }
 
-function getCertName() {
+function getCertCommonName() {
   return certCommonName;
 }
 
-function getCertPath(argv) {
-  return argv.sslCert || defaultCertPath;
+function getCertName() {
+  return certName;
 }
 
-function getKeyPath(argv) {
-  return argv.sslKey || defaultKeyPath;
+function getKeyName() {
+  return keyName;
 }
 
-function remove(argv) {
-  fs.removeSync(getCertPath(argv));
-  fs.removeSync(getKeyPath(argv));
+function getCertPath() {
+  return defaultCertPath;
+}
+
+function getKeyPath() {
+  return defaultKeyPath;
+}
+
+function remove() {
+  fs.removeSync(defaultCertDir);
 }
 
 module.exports = {
   generate,
+  getCertCommonName,
   getCertName,
+  getKeyName,
   getCertPath,
   getKeyPath,
   remove,

--- a/lib/utils/cert-utils.js
+++ b/lib/utils/cert-utils.js
@@ -41,11 +41,39 @@ function generate() {
   const now = new Date();
   const keys = forge.pki.rsa.generateKeyPair(2048);
   const certificate = forge.pki.createCertificate();
-  const attrs = [{
-    name: 'commonName',
-    value: 'localhost'
-  }];
 
+  const attrs = [
+    {
+      name: 'commonName',
+      value: getCertCommonName()
+    },
+    {
+      name: 'countryName',
+      value: 'US'
+    },
+    {
+      name: 'stateOrProvinceName',
+      value: 'SC'
+    },
+    {
+      name: 'localityName',
+      value: 'Charleston'
+    },
+    {
+      name: 'organizationName',
+      value: 'Blackbaud'
+    },
+    {
+      name: 'organizationalUnitName',
+      value: 'Research, Delivery, and Operations'
+    },
+    {
+      name: 'emailAddress',
+      value: 'sky-build-user@blackbaud.com'
+    }
+  ];
+
+  certificate.serialNumber = '01';
   certificate.publicKey = keys.publicKey;
   certificate.validity.notBefore = now;
   certificate.validity.notAfter.setFullYear(certificate.validity.notBefore.getFullYear() + 1);
@@ -55,23 +83,32 @@ function generate() {
   certificate.setExtensions([
     {
       name: 'subjectAltName',
-      altNames: [{
-        type: 2, // DNS
-        value: 'localhost'
-      }]
+      altNames: [
+        {
+          type: 2,
+          value: 'localhost'
+        }
+      ]
     },
     {
       name: 'keyUsage',
+      dataEncipherment: true,
       digitalSignature: true,
       keyEncipherment: true,
-      dataEncipherment: true
-    }, {
+      nonRepudiation: true,
+      critical: true
+    },
+    {
       name: 'extKeyUsage',
-      serverAuth: true
-    }, {
-      name: 'friendlyName',
-      value: getCertCommonName()
-    }]);
+      serverAuth: true,
+      clientAuth: true
+    },
+    {
+      name: 'basicConstraints',
+      cA: false,
+      critical: true
+    }
+  ]);
 
   certificate.sign(keys.privateKey, forge.md.sha256.create());
 

--- a/lib/utils/spawn.js
+++ b/lib/utils/spawn.js
@@ -9,11 +9,16 @@ function run(...args) {
     logger.info(`Executing: \`${script}\``);
     const running = spawn(command, args, { stdio: 'inherit' });
 
+    running.on('error', (err) => {
+      logger.error(`\nError executing (code 0): \`${script}\``);
+      reject(err);
+    });
+
     running.on('exit', (code) => {
       if (code === 0) {
         resolve();
       } else {
-        logger.error(`\nError executing: \`${script}\``);
+        logger.error(`\nError executing (code 1): \`${script}\``);
         reject(code);
       }
     });

--- a/test/lib-certs.spec.js
+++ b/test/lib-certs.spec.js
@@ -19,6 +19,7 @@ describe('skyux certs command', () => {
       'remove',
       'validate'
     ]);
+    spyCertUtils.validate.and.returnValue(true);
     mock('../lib/utils/cert-utils', spyCertUtils);
     return spyCertUtils;
   }
@@ -138,7 +139,7 @@ describe('skyux certs command', () => {
 
       // Handles the uninstall action
       setup.spyCertUtils.remove.and.throwError(err);
-      
+
       await setup.lib(setup.argv);
       expect(logger.error).toHaveBeenCalledWith(
         `Unable to ${action} the SKY UX certificate.`
@@ -152,6 +153,13 @@ describe('skyux certs command', () => {
 
   describe('uninstall action', () => {
     runActionTests('uninstall');
+  });
+
+  it('should not call uninstall when executing install if validate is false', async () => {
+    const setup = setupPlatformTest('install', 'Windows_NT');
+    setup.spyCertUtils.validate.and.returnValue(false);
+    await setup.lib(setup.argv);
+    expect(setup.spyCertUtils.remove).not.toHaveBeenCalled();
   });
 
   it('should handle the generate action', () => {

--- a/test/lib-certs.spec.js
+++ b/test/lib-certs.spec.js
@@ -27,7 +27,7 @@ describe('skyux certs command', () => {
     return mock.reRequire('../lib/certs');
   }
 
-  async function setupPlatformTest(action, platform, includeNoPause) {
+  function setupPlatformTest(action, platform, includeNoPause) {
     const argv = { _: ['certs', action]};
 
     // minimist converts --no-pause to pause: false
@@ -46,9 +46,10 @@ describe('skyux certs command', () => {
     const spyCertUtils = spyOnCertUtils();
 
     const lib = getLib();
-    await lib(argv);
 
     return {
+      argv,
+      lib,
       spySpawn,
       spyOn,
       spyCertUtils
@@ -56,29 +57,61 @@ describe('skyux certs command', () => {
   }
 
   async function runPlatformTest(action, platform, includeNoPause) {
-    const spies = await setupPlatformTest(action, platform, includeNoPause);
+    const setup = setupPlatformTest(action, platform, includeNoPause);
+    await setup.lib(setup.argv);
+
     if (action === 'install') {
-      expect(spies.spyCertUtils.generate).toHaveBeenCalled();
+      expect(setup.spyCertUtils.generate).toHaveBeenCalled();
     }
     if (action === 'uninstall') {
-      expect(spies.spyCertUtils.remove).toHaveBeenCalled();
+      expect(setup.spyCertUtils.remove).toHaveBeenCalled();
     }
-    expect(spies.spySpawn).toHaveBeenCalled();
-    return spies;
+    expect(setup.spySpawn).toHaveBeenCalled();
+    return setup;
   }
 
   function runActionTests(action) {
     it('should handle the Darwin (mac) platform', async () => {
       await runPlatformTest(action, 'Darwin');
     });
+
+    it('should handle an error on the Darwin (mac) platform', async () => {
+      const err = 'custom-error';
+      const setup = setupPlatformTest(action, 'Darwin');
+
+      setup.spySpawn.and.throwError(err);
+      await setup.lib(setup.argv)
+
+      expect(logger.error).toHaveBeenCalledWith(`Unsuccessful in completing last task: ${new Error(err)}`);
+    });
   
     it('should handle the Linux platform', async () => {
       await runPlatformTest(action, 'Linux');
+    });
+
+    it('should handle an error on the Linux platform', async () => {
+      const err = 'custom-error';
+      const setup = setupPlatformTest(action, 'Linux');
+      
+      setup.spySpawn.and.throwError(err);
+      await setup.lib(setup.argv)
+
+      expect(logger.error).toHaveBeenCalledWith(`Unsuccessful in completing last task: ${new Error(err)}`);
     });
   
     it('should handle the Windows platform', async () => {
       const spies = await runPlatformTest(action, 'Windows_NT');
       expect(spies.spySpawn.calls.argsFor(0)[1].indexOf('PAUSE')).not.toEqual(-1);
+    });
+
+    it('should handle an error on the Windows platform', async () => {
+      const err = 'custom-error';
+      const setup = setupPlatformTest(action, 'Windows_NT');
+      
+      setup.spySpawn.and.throwError(err);
+      await setup.lib(setup.argv)
+
+      expect(logger.error).toHaveBeenCalledWith(`Unsuccessful in completing last task: ${new Error(err)}`);
     });
 
     it('should handle the Windows platform (with --no-pause)', async () => {
@@ -87,9 +120,28 @@ describe('skyux certs command', () => {
     });
 
     it('should handle an unknown platform', async () => {
-      await setupPlatformTest(action, 'unknown-platform');
+      const setup = await setupPlatformTest(action, 'unknown-platform');
+      await setup.lib(setup.argv);
+
       expect(logger.error).toHaveBeenCalledWith(
         `Unable to automatically ${action} based on your OS.`
+      )
+    });
+
+    it('should handle an error when generating', async () => {
+      // Any support platform
+      const setup = setupPlatformTest(action, 'Windows_NT');
+      const err = 'custom-error';
+
+      // Handles the install action
+      setup.spyCertUtils.generate.and.throwError(err);
+
+      // Handles the uninstall action
+      setup.spyCertUtils.remove.and.throwError(err);
+      
+      await setup.lib(setup.argv);
+      expect(logger.error).toHaveBeenCalledWith(
+        `Unable to ${action} the SKY UX certificate.`
       )
     });
   }
@@ -125,18 +177,5 @@ describe('skyux certs command', () => {
     lib({ _: ['certs', 'asdf']});
     expect(logger.warn).toHaveBeenCalledWith(`Unknown action for the certs command.`);
     expect(logger.warn).toHaveBeenCalledWith(`Available actions are install and uninstall.`);
-  });
-
-  it('should handle an error', () => {
-    const err = 'fake-error';
-    const argv = { _: ['certs', 'validate']};
-    const spyCertUtils = spyOnCertUtils();
-    spyCertUtils.validate.and.callFake(() => {
-      throw err;
-    });
-    const lib = getLib();
-    
-    lib(argv);
-    expect(logger.error).toHaveBeenCalledWith(`Command exited with error: ${err}`);
   });
 });

--- a/test/lib-certs.spec.js
+++ b/test/lib-certs.spec.js
@@ -11,7 +11,9 @@ describe('skyux certs command', () => {
   function spyOnCertUtils() {
     const spyCertUtils = jasmine.createSpyObj('certUtils', [
       'generate',
+      'getCertCommonName',
       'getCertName',
+      'getKeyName',
       'getCertPath',
       'getKeyPath',
       'remove',
@@ -106,7 +108,7 @@ describe('skyux certs command', () => {
     const lib = getLib();
     
     lib(argv);
-    expect(spyCertUtils.generate).toHaveBeenCalledWith(argv);    
+    expect(spyCertUtils.generate).toHaveBeenCalled();    
   });
 
   it('should handle the validate action', () => {
@@ -115,7 +117,7 @@ describe('skyux certs command', () => {
     const lib = getLib();
     
     lib(argv);
-    expect(spyCertUtils.validate).toHaveBeenCalledWith(argv);
+    expect(spyCertUtils.validate).toHaveBeenCalled();
   });
 
   it('should handle an unknown action', () => {

--- a/test/skyux.spec.js
+++ b/test/skyux.spec.js
@@ -480,4 +480,23 @@ describe('skyux CLI', () => {
     });
   });
 
+  it('should not validate the cert if --sslCert and --sslKey are passed in', () => {
+    const certUtilsSpy = jasmine.createSpyObj('certUtils', ['validate', 'getCertPath', 'getKeyPath']);
+
+    mock('../lib/utils/cert-utils', certUtilsSpy);
+    mock('glob', {
+      sync: () => []
+    });
+
+    // minimist converts --sslCert and --sslKey to properties
+    const argv = {
+      _: ['serve'],
+      sslCert: 'custom-cert',
+      sslKey: 'custom-key'
+    };
+
+    cli(argv);
+    expect(certUtilsSpy.validate).not.toHaveBeenCalled();
+  });
+
 });


### PR DESCRIPTION
Description of PR.  

1. For any action `skyux certs` processes, I've removed the ability to override the `--sslCert` and `--sslKey`.  After further discussion, it felt weird that I let those be overridden when doing things like deleting from the filesystem and auto trusting.

2. I also adjusted to delete the entire `.skyux/certs` folder since I needed to change the extension of the cert (to make Linux happy).

3. Wrapped individual commands in `try/catch` since in some cases, we want to continue to the next step.  For example, when attempting to delete any old certificates, continue with installing new ones.

4. Introduced writing to the NSS certificate store on Linux.  I imagine in future updates being able to do so for Firefox as well.

5. Properly handling `spawn`'s error event.

Tested manually by me in macOS and Linux.  Tested manually by @Blackbaud-TerryHelems in Windows.  Tested in automation in https://github.com/blackbaud/skyux-sdk-builder/pull/175 and https://blackbaud.visualstudio.com/Products/_build/results?buildId=831913&_a=summary&view=results