### PR TITLE
Addressed Chrome on Linux

### DIFF
--- a/lib/utils/certs/generator.js
+++ b/lib/utils/certs/generator.js
@@ -90,10 +90,6 @@ function getCertificateAttributes(commonName) {
     {
       name: 'organizationalUnitName',
       value: 'Research, Delivery, and Operations'
-    },
-    {
-      name: 'emailAddress',
-      value: 'sky-build-user@blackbaud.com'
     }
   ];
 }
@@ -123,16 +119,13 @@ function generate() {
     },
     {
       name: 'keyUsage',
-      dataEncipherment: true,
       digitalSignature: true,
       keyEncipherment: true,
-      nonRepudiation: true,
       critical: true
     },
     {
       name: 'extKeyUsage',
-      serverAuth: true,
-      clientAuth: true
+      serverAuth: true
     },
     {
       name: 'basicConstraints',

--- a/lib/utils/certs/generator.js
+++ b/lib/utils/certs/generator.js
@@ -100,7 +100,7 @@ function getCertificateAttributes(commonName) {
 
 function generate() {
   const certAuthExtensions = [
-    { 
+    {
       name: 'basicConstraints',
       cA: true,
       critical: true
@@ -154,7 +154,7 @@ function generate() {
 
   logger.info(`Generating ${getCertCommonName()}`);
   const certificate = generateCertificate(
-    certExtensions, 
+    certExtensions,
     certAttributes,
     certAuthAttributes,
     `${now}-02`,

--- a/lib/utils/certs/os-linux.js
+++ b/lib/utils/certs/os-linux.js
@@ -21,7 +21,7 @@ async function trust() {
 
   if (fs.existsSync(linuxChromeNSSPath)) {
     await execute('trust', 'NSS Chrome', async () => {
-      await spawn(`certutil`, `-d`, `sql:${linuxChromeNSSPath}`, `-A`, `-t`, `P`, `-n`, generator.getCertAuthCommonName(), `-i`, generator.getCertPath());
+      await spawn(`certutil`, `-d`, `sql:${linuxChromeNSSPath}`, `-A`, `-t`, `C`, `-n`, generator.getCertAuthCommonName(), `-i`, generator.getCertAuthPath());
     });
   } else {
     logAutomationSkip('trust', 'NSS Chrome')
@@ -37,7 +37,12 @@ async function untrust() {
 
   if (fs.existsSync(linuxChromeNSSPath)) {
     await execute('untrust', 'NSS Chrome', async () => {
-      await spawn(`certutil`, `-D`, `-d`, `sql:${linuxChromeNSSPath}`, `-n`, generator.getCertCommonName());
+      try {
+        await spawn(`certutil`, `-D`, `-d`, `sql:${linuxChromeNSSPath}`, `-n`, generator.getCertCommonName());
+      } catch (err) {
+        logger.info('Certificate from old technique did not exist. OK to proceed and ignore previous error.');
+      }
+
       await spawn(`certutil`, `-D`, `-d`, `sql:${linuxChromeNSSPath}`, `-n`, generator.getCertAuthCommonName());
     });
   } else {

--- a/test/lib-utils-certs-os-linux.spec.js
+++ b/test/lib-utils-certs-os-linux.spec.js
@@ -151,7 +151,7 @@ describe('cert utils linux', () => {
     expect(results.spyPath.resolve).toHaveBeenCalledWith(`${results.homeDir}/.pki/nssdb`);
     expect(results.spyExecute).toHaveBeenCalledWith('trust', 'NSS Chrome', jasmine.any(Function));
     expect(results.spySpawn).toHaveBeenCalledWith(
-      `certutil`, `-d`, `sql:${results.linuxChromeNSSPath}`, `-A`, `-t`, `P`, `-n`, results.certAuthCommonName, `-i`, results.certPath
+      `certutil`, `-d`, `sql:${results.linuxChromeNSSPath}`, `-A`, `-t`, `C`, `-n`, results.certAuthCommonName, `-i`, results.certAuthPath
     );
   });
 

--- a/test/lib-utils-certs-os-linux.spec.js
+++ b/test/lib-utils-certs-os-linux.spec.js
@@ -82,7 +82,7 @@ describe('cert utils linux', () => {
     };
   }
 
-  async function setupForNSS(action) {
+  async function setupForNSS() {
     const homeDir = 'home-dir';
     const linuxChromeNSSPath = 'nssdb';
     const certAuthCommonName = 'cert-auth-common-name';
@@ -106,9 +106,6 @@ describe('cert utils linux', () => {
     spyGenerator.getCertCommonName.and.returnValue(certCommonName);
     spyExecute.and.callFake((command, level, cb) => level === 'NSS Chrome' ? cb() : Promise.resolve());
 
-    const lib = getLib();
-    await lib[action]();
-
     return {
       homeDir,
       linuxChromeNSSPath,
@@ -123,6 +120,17 @@ describe('cert utils linux', () => {
       spyExecute,
       spySpawn
     };
+  }
+
+  async function runForNSS(action) {
+    const lib = getLib();
+    return await lib[action]();
+  }
+
+  async function testForNSS(action) {
+    const spies = await setupForNSS();
+    spies.results = await runForNSS(action);
+    return spies;
   }
 
   it('should expose a public API', () => {
@@ -147,7 +155,7 @@ describe('cert utils linux', () => {
   });
 
   it('should trust at the NSS level', async () => {
-    const results = await setupForNSS('trust');
+    const results = await testForNSS('trust');
     expect(results.spyPath.resolve).toHaveBeenCalledWith(`${results.homeDir}/.pki/nssdb`);
     expect(results.spyExecute).toHaveBeenCalledWith('trust', 'NSS Chrome', jasmine.any(Function));
     expect(results.spySpawn).toHaveBeenCalledWith(
@@ -173,13 +181,35 @@ describe('cert utils linux', () => {
   });
 
   it('should untrust at the NSS level', async () => {
-    const results = await setupForNSS('untrust');
+    const results = await testForNSS('untrust');
     expect(results.spyExecute).toHaveBeenCalledWith('untrust', 'NSS Chrome', jasmine.any(Function));
     expect(results.spySpawn).toHaveBeenCalledWith(
       `certutil`, `-D`, `-d`, `sql:${results.linuxChromeNSSPath}`, `-n`, results.certCommonName
     );
     expect(results.spySpawn).toHaveBeenCalledWith(
       `certutil`, `-D`, `-d`, `sql:${results.linuxChromeNSSPath}`, `-n`, results.certAuthCommonName
+    );
+  });
+
+  it('should untrust at the NSS level and handle the old certificate not existing', async () => {
+    const spies = await setupForNSS();
+
+    // Emulate not finding the old certificate
+    spies.spySpawn.and.callFake(async (...args) => {
+      return args[args.length - 1] === spies.certCommonName ? Promise.reject() : Promise.resolve();
+    });
+
+    await runForNSS('untrust');
+
+    expect(spies.spyExecute).toHaveBeenCalledWith('untrust', 'NSS Chrome', jasmine.any(Function));
+    expect(spies.spySpawn).toHaveBeenCalledWith(
+      `certutil`, `-D`, `-d`, `sql:${spies.linuxChromeNSSPath}`, `-n`, spies.certCommonName
+    );
+    expect(spies.spySpawn).toHaveBeenCalledWith(
+      `certutil`, `-D`, `-d`, `sql:${spies.linuxChromeNSSPath}`, `-n`, spies.certAuthCommonName
+    );
+    expect(logger.info).toHaveBeenCalledWith(
+      'Certificate from old technique did not exist. OK to proceed and ignore previous error.'
     );
   });
 


### PR DESCRIPTION
### Problem
It's unclear where the regression was introduced - Linux, Chrome, or the `node-forge` library - but the generated certificate used in Chrome on Linux was no longer valid.

The certificate generated and was trusted in the NSS database fine, but when attempting to serve a SPA, Chrome would not show the CA and simply said "missing."

After digging through the properties we set on the CA and server certificate, I found setting the `emailAddress` to a value which contains `@`, as all email addresses do`, causes the behavior.

### Solution

This PR ended up addressing a few items in addition to the certificate not working.

- Trusting of CA in NSS DB was attempting to trust as `P` instead of `C` as well as attempting to import the certificate path instead of the CA path.
- Removed a few unneeded properties given our use-case.
- Removed `emailAddress` (fixes original certificate issue)
- Wrapped removal of old trusted certificate (not CA) in `try/catch` since it won't be there for users going forward (we switched from trusting certificate to CA, but still need to remove the certificate). #56 

I've manually tested on Mac, Linux, and Windows with the help of @Blackbaud-TerryHelems and @Blackbaud-JasonBodnar.