### PR TITLE
[rc] Adjustments to `skyux upgrade`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,13 @@ os:
   - osx
 # Enable after https://travis-ci.community/t/current-known-issues-please-read-this-before-posting-a-new-topic/264/23
 #  - windows
-  
+
 language: node_js
 
 branches:
   only:
     - master
+    - /^rc-.*$/
     - /^[0-9]+\.[0-9]+\.[0-9]+.*/
 
 env:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,7 @@
 branches:
   only:
     - master
+    - /^rc-.*$/
 
 environment:
   nodejs_version: "10"

--- a/lib/app-dependencies.js
+++ b/lib/app-dependencies.js
@@ -149,13 +149,11 @@ async function upgradeDependencies(dependencies) {
           );
           break;
         default:
-          if (
-            /^[0-9]+\./.test(currentVersion) ||
-            /-(rc|alpha|beta)\./.test(currentVersion)
-          ) {
-            versionRange = `^${currentVersion.replace('^', '').replace('~', '')}`;
+          if (/^[0-9]+\./.test(currentVersion)) {
+            // Convert the specific version into a range.
+            versionRange = `^${currentVersion}`;
           } else {
-            // Allow package.json to request a version based on an NPM tag (e.g. 'next').
+            // Current version already specifies a range.
             versionRange = currentVersion;
           }
 

--- a/lib/app-dependencies.js
+++ b/lib/app-dependencies.js
@@ -4,6 +4,8 @@ const logger = require('@blackbaud/skyux-logger');
 
 const sortUtils = require('../lib/utils/sort-utils');
 
+const LOG_SEPARATOR = '-----';
+
 /**
  * Alphabetizes dependencies, similar to the behavior of `npm install <package> --save`.
  * @param {*} dependencies Dependencies to sort.
@@ -62,9 +64,10 @@ async function addSkyPeerDependencies(dependencies) {
       );
     });
 
-    const peerPromises = skyPackageNames.map(
-      packageName => getPackageJson(packageName)
-    );
+    const peerPromises = skyPackageNames.map(packageName => {
+      const version = dependencies[packageName];
+      return getPackageJson(packageName, { version });
+    });
 
     const packageJsonList = await Promise.all(peerPromises);
 
@@ -73,7 +76,7 @@ async function addSkyPeerDependencies(dependencies) {
       if (packageJson.peerDependencies) {
         for (const peerDependency of Object.keys(packageJson.peerDependencies)) {
           if (!dependencies[peerDependency]) {
-            logger.info(`Adding package ${peerDependency} since it is a peer dependency of ${packageJson.name}...`);
+            logger.info(`Added package ${peerDependency} since it is a peer dependency of ${packageJson.name}@${packageJson.version}.`);
             dependencies[peerDependency] = 'latest';
             foundNewDependency = true;
           }
@@ -87,6 +90,8 @@ async function addSkyPeerDependencies(dependencies) {
   fixDependencyOrder(dependencies);
 
   if (foundNewDependency) {
+    logger.info(LOG_SEPARATOR);
+
     // New dependencies were added, so we need to run the peer check again.
     await addSkyPeerDependencies(dependencies);
   }
@@ -94,10 +99,6 @@ async function addSkyPeerDependencies(dependencies) {
 
 async function upgradeDependencies(dependencies) {
   if (dependencies) {
-
-    // Make sure any versions listed as 'latest' are converted to
-    // the numeric equivalent.
-    await setDependencyVersions(dependencies);
 
     const promises = [];
 
@@ -110,13 +111,19 @@ async function upgradeDependencies(dependencies) {
         case 'typescript':
           versionRange = '~3.6.4';
           logger.info(
-            `NOTE: Using version range (${packageName}@${versionRange}) because TypeScript does not support semantic versioning.`
+            `NOTE: Using version range ${packageName}@${versionRange} because TypeScript does not support semantic versioning.`
           );
           break;
         case 'zone.js':
           versionRange = '~0.10.2';
           logger.info(
-            `NOTE: Using version range (${packageName}@${versionRange}) because Angular requires a specific version of ${packageName}.`
+            `NOTE: Using version range ${packageName}@${versionRange} because Angular requires a specific minor version of ${packageName}.`
+          );
+          break;
+        case 'ts-node':
+          versionRange = '~8.6.0';
+          logger.info(
+            `NOTE: Using version range ${packageName}@${versionRange} because Angular requires a specific minor version of ${packageName}.`
           );
           break;
         default:
@@ -124,13 +131,13 @@ async function upgradeDependencies(dependencies) {
             /^[0-9]+\./.test(currentVersion) ||
             /-(rc|alpha|beta)\./.test(currentVersion)
           ) {
-            versionRange = `^${currentVersion}`;
+            versionRange = `^${currentVersion.replace('^', '').replace('~', '')}`;
           } else {
             // Allow package.json to request a version based on an NPM tag (e.g. 'next').
             versionRange = currentVersion;
           }
 
-          logger.info(`Finding latest version within range (${packageName}@${versionRange})...`);
+          logger.info(`Finding latest version within range: ${packageName}@${versionRange}.`);
           break;
       }
 
@@ -143,15 +150,28 @@ async function upgradeDependencies(dependencies) {
 
     const versionNumbers = await Promise.all(promises);
 
+    const updateMessages = [];
+    const ignoreMessages = [];
+
     Object.keys(dependencies).forEach((packageName, index) => {
       const versionNumber = versionNumbers[index];
       if (dependencies[packageName] === versionNumber) {
-        logger.info(`Skipping package update. ${packageName} already set to (${versionNumber}).`);
+        ignoreMessages.push(`Skipping package ${packageName} because it is already set to (${versionNumber}).`);
       } else {
-        logger.info(`Updated package ${packageName} to version (${versionNumber}).`);
-        dependencies[packageName] = versionNumber;
+        updateMessages.push(`Updated package ${packageName} to (${versionNumber}).`);
       }
+      dependencies[packageName] = versionNumber;
     });
+
+    if (ignoreMessages.length) {
+      ignoreMessages.forEach(m => logger.info(m));
+      logger.info(LOG_SEPARATOR);
+    }
+
+    if (updateMessages.length) {
+      updateMessages.forEach(m => logger.info(m));
+      logger.info(LOG_SEPARATOR);
+    }
   }
 
   fixDependencyOrder(dependencies);

--- a/lib/app-dependencies.js
+++ b/lib/app-dependencies.js
@@ -94,60 +94,62 @@ async function addSkyPeerDependencies(dependencies) {
 
 async function upgradeDependencies(dependencies) {
   if (dependencies) {
-    const dependencyPromises = [];
 
     // Make sure any versions listed as 'latest' are converted to
     // the numeric equivalent.
     await setDependencyVersions(dependencies);
 
-    const packageNames = Object.keys(dependencies);
+    const promises = [];
 
-    for (const packageName of packageNames) {
+    for (const packageName in dependencies) {
       const currentVersion = dependencies[packageName];
 
-      let dependencyPromise;
+      let versionRange;
 
-      if (/^[0-9]+\./.test(currentVersion)) {
-        let majorVersion = currentVersion.split('.')[0];
-
-        // Handle prerelease versions.
-        if (/-(rc|alpha|beta)\./.test(currentVersion)) {
-          majorVersion = `^${currentVersion}`;
-        }
-
-        logger.info(`Installing version (${majorVersion}) for ${packageName}...`);
-
-        dependencyPromise = latestVersion(
-          packageName,
-          {
-            version: `${majorVersion}`
-          }
-        );
-      } else {
-        dependencyPromise = Promise.resolve(currentVersion);
-      }
-
-      dependencyPromises.push(dependencyPromise);
-    }
-
-    const versionNumbers = await Promise.all(dependencyPromises);
-
-    packageNames.forEach((packageName, index) => {
-      const versionNumber = versionNumbers[index];
       switch (packageName) {
         case 'typescript':
-          logger.info('Skipping TypeScript because it does not use semantic versioning.');
+          versionRange = '~3.6.4';
+          logger.info(
+            `NOTE: Using version range (${packageName}@${versionRange}) because TypeScript does not support semantic versioning.`
+          );
           break;
         case 'zone.js':
-          logger.info('Skipping Zone.js because Angular requires a specific minor version.');
+          versionRange = '~0.10.2';
+          logger.info(
+            `NOTE: Using version range (${packageName}@${versionRange}) because Angular requires a specific version of ${packageName}.`
+          );
           break;
         default:
-          if (dependencies[packageName] === versionNumber) {
-            logger.info(`Package ${packageName} already on version (${versionNumber}).`);
+          if (
+            /^[0-9]+\./.test(currentVersion) ||
+            /-(rc|alpha|beta)\./.test(currentVersion)
+          ) {
+            versionRange = `^${currentVersion}`;
           } else {
-            logger.info(`Updated package ${packageName} to version (${versionNumber}).`);
-            dependencies[packageName] = versionNumber;
+            // Allow package.json to request a version based on an NPM tag (e.g. 'next').
+            versionRange = currentVersion;
           }
+
+          logger.info(`Finding latest version within range (${packageName}@${versionRange})...`);
+          break;
+      }
+
+      promises.push(
+        latestVersion(packageName, {
+          version: `${versionRange}`
+        })
+      );
+    }
+
+    const versionNumbers = await Promise.all(promises);
+
+    Object.keys(dependencies).forEach((packageName, index) => {
+      const versionNumber = versionNumbers[index];
+      if (dependencies[packageName] === versionNumber) {
+        logger.info(`Skipping package update. ${packageName} already set to (${versionNumber}).`);
+      } else {
+        logger.info(`Updated package ${packageName} to version (${versionNumber}).`);
+        dependencies[packageName] = versionNumber;
       }
     });
   }

--- a/lib/app-dependencies.js
+++ b/lib/app-dependencies.js
@@ -35,10 +35,9 @@ async function setDependencyVersions(dependencies) {
   const packageNames = Object.keys(dependencies);
 
   const dependencyPromises = packageNames.map(
-    packageName => dependencies[packageName] === 'latest' ?
-      latestVersion(packageName) :
-      // Default to the specified version.
-      Promise.resolve(dependencies[packageName])
+    packageName => latestVersion(packageName, {
+      version: dependencies[packageName]
+    })
   );
 
   const versionNumbers = await Promise.all(dependencyPromises);
@@ -71,17 +70,42 @@ async function addSkyPeerDependencies(dependencies) {
 
     const packageJsonList = await Promise.all(peerPromises);
 
+    const ignoredPackages = [];
+
     for (const packageJson of packageJsonList) {
       /* istanbul ignore else */
       if (packageJson.peerDependencies) {
-        for (const peerDependency of Object.keys(packageJson.peerDependencies)) {
-          if (!dependencies[peerDependency]) {
-            logger.info(`Added package ${peerDependency} since it is a peer dependency of ${packageJson.name}@${packageJson.version}.`);
-            dependencies[peerDependency] = 'latest';
-            foundNewDependency = true;
+        for (const packageName of Object.keys(packageJson.peerDependencies)) {
+          if (dependencies[packageName]) {
+            continue;
           }
+
+          // Only handle Angular and SKY UX packages.
+          if (/^(@angular|@skyux|@blackbaud)/.test(packageName) === false) {
+            // We can ignore reporting `tslib` since it's installed by Builder.
+            if (packageName !== 'tslib') {
+              ignoredPackages.push({
+                missingPeer: `${packageName}@${packageJson.peerDependencies[packageName]}`,
+                peer: `${packageJson.name}@${packageJson.version}`
+              });
+            }
+            continue;
+          }
+
+          logger.info(`Added package ${packageName}@${packageJson.peerDependencies[packageName]} since it is a peer dependency of ${packageJson.name}@${packageJson.version}.`);
+          dependencies[packageName] = packageJson.peerDependencies[packageName];
+          foundNewDependency = true;
         }
       }
+    }
+
+    if (ignoredPackages.length) {
+      logger.info('Warning: The following missing peer dependencies were not added because they are not known Angular or SKY UX packages. Do you need to install them yourself?');
+      logger.info(LOG_SEPARATOR);
+      ignoredPackages.forEach(p => logger.info(
+        `${p.missingPeer} --> peer of ${p.peer}`
+      ));
+      logger.info(LOG_SEPARATOR);
     }
 
     await setDependencyVersions(dependencies);
@@ -90,8 +114,6 @@ async function addSkyPeerDependencies(dependencies) {
   fixDependencyOrder(dependencies);
 
   if (foundNewDependency) {
-    logger.info(LOG_SEPARATOR);
-
     // New dependencies were added, so we need to run the peer check again.
     await addSkyPeerDependencies(dependencies);
   }
@@ -111,19 +133,19 @@ async function upgradeDependencies(dependencies) {
         case 'typescript':
           versionRange = '~3.6.4';
           logger.info(
-            `NOTE: Using version range ${packageName}@${versionRange} because TypeScript does not support semantic versioning.`
+            `Note: Using version range ${packageName}@${versionRange} because TypeScript does not support semantic versioning.`
           );
           break;
         case 'zone.js':
           versionRange = '~0.10.2';
           logger.info(
-            `NOTE: Using version range ${packageName}@${versionRange} because Angular requires a specific minor version of ${packageName}.`
+            `Note: Using version range ${packageName}@${versionRange} because Angular requires a specific minor version of ${packageName}.`
           );
           break;
         case 'ts-node':
           versionRange = '~8.6.0';
           logger.info(
-            `NOTE: Using version range ${packageName}@${versionRange} because Angular requires a specific minor version of ${packageName}.`
+            `Note: Using version range ${packageName}@${versionRange} because Angular requires a specific minor version of ${packageName}.`
           );
           break;
         default:
@@ -137,7 +159,7 @@ async function upgradeDependencies(dependencies) {
             versionRange = currentVersion;
           }
 
-          logger.info(`Finding latest version within range: ${packageName}@${versionRange}.`);
+          logger.info(`Finding latest version within range ${packageName}@${versionRange}...`);
           break;
       }
 
@@ -156,7 +178,7 @@ async function upgradeDependencies(dependencies) {
     Object.keys(dependencies).forEach((packageName, index) => {
       const versionNumber = versionNumbers[index];
       if (dependencies[packageName] === versionNumber) {
-        ignoreMessages.push(`Skipping package ${packageName} because it is already set to (${versionNumber}).`);
+        ignoreMessages.push(`Skipped package ${packageName} because it is already set to (${versionNumber}).`);
       } else {
         updateMessages.push(`Updated package ${packageName} to (${versionNumber}).`);
       }
@@ -172,6 +194,9 @@ async function upgradeDependencies(dependencies) {
       updateMessages.forEach(m => logger.info(m));
       logger.info(LOG_SEPARATOR);
     }
+
+    logger.info(`Total packages upgraded: ${updateMessages.length}`);
+    logger.info(LOG_SEPARATOR);
   }
 
   fixDependencyOrder(dependencies);

--- a/lib/app-dependencies.js
+++ b/lib/app-dependencies.js
@@ -1,5 +1,6 @@
 const latestVersion = require('latest-version');
 const getPackageJson = require('package-json');
+const semver = require('semver');
 const logger = require('@blackbaud/skyux-logger');
 
 const sortUtils = require('../lib/utils/sort-utils');
@@ -126,6 +127,7 @@ async function upgradeDependencies(dependencies) {
 
     for (const packageName in dependencies) {
       const currentVersion = dependencies[packageName];
+      const validRange = semver.validRange(currentVersion);
 
       let versionRange;
 
@@ -149,11 +151,14 @@ async function upgradeDependencies(dependencies) {
           );
           break;
         default:
-          if (/^[0-9]+\./.test(currentVersion)) {
+          if (validRange === currentVersion) {
             // Convert the specific version into a range.
             versionRange = `^${currentVersion}`;
+          } else if (validRange !== null) {
+            // Use the validated range.
+            versionRange = validRange;
           } else {
-            // Current version already specifies a range.
+            // Current version specifies a dist-tag or git URL.
             versionRange = currentVersion;
           }
 

--- a/lib/app-dependencies.js
+++ b/lib/app-dependencies.js
@@ -115,7 +115,7 @@ async function upgradeDependencies(dependencies) {
           majorVersion = `^${currentVersion}`;
         }
 
-        logger.info(`Getting latest ${packageName} version for major version ${majorVersion}...`);
+        logger.info(`Installing version (${majorVersion}) for ${packageName}...`);
 
         dependencyPromise = latestVersion(
           packageName,
@@ -143,9 +143,9 @@ async function upgradeDependencies(dependencies) {
           break;
         default:
           if (dependencies[packageName] === versionNumber) {
-            logger.info(`Package ${packageName} already on latest version (${versionNumber})`);
+            logger.info(`Package ${packageName} already on version (${versionNumber}).`);
           } else {
-            logger.info(`Updating package ${packageName} to version ${versionNumber}`);
+            logger.info(`Updated package ${packageName} to version (${versionNumber}).`);
             dependencies[packageName] = versionNumber;
           }
       }

--- a/lib/upgrade.js
+++ b/lib/upgrade.js
@@ -4,11 +4,6 @@ const appDependencies = require('../lib/app-dependencies');
 const jsonUtils = require('../lib/utils/json-utils');
 const cleanup = require('../lib/cleanup');
 
-function isReferenced(packageName, packageJson) {
-  return (packageJson.devDependencies && packageJson.devDependencies[packageName]) ||
-    (packageJson.dependencies && packageJson.dependencies[packageName]);
-}
-
 async function upgrade() {
 
   const packageJson = await jsonUtils.readJson('package.json');
@@ -23,16 +18,7 @@ async function upgrade() {
 
   await cleanup.deleteDependencies();
 
-  let doneMsg = 'Done.';
-
-  if (isReferenced('typescript', packageJson) || isReferenced('zone.js', packageJson)) {
-    doneMsg += '  This project includes a reference to TypeScript and/or Zone.js, but the versions ' +
-    'were not updated automatically because of Angular\'s version requirements for these libraries.  ' +
-    'If running `skyux install` results in a peer dependency warning for one of these libraries, you may ' +
-    'need to update these versions manually.';
-  }
-
-  logger.info(doneMsg);
+  logger.info('Done.');
 }
 
 module.exports = upgrade;

--- a/package-lock.json
+++ b/package-lock.json
@@ -823,6 +823,12 @@
           "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
           "dev": true
         },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        },
         "shebang-command": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -1447,6 +1453,14 @@
         "@istanbuljs/schema": "^0.1.2",
         "istanbul-lib-coverage": "^3.0.0",
         "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
       }
     },
     "istanbul-lib-processinfo": {
@@ -1670,6 +1684,13 @@
       "integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
       "requires": {
         "semver": "^6.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        }
       }
     },
     "merge-descriptors": {
@@ -1946,6 +1967,13 @@
         "registry-auth-token": "^4.0.0",
         "registry-url": "^5.0.0",
         "semver": "^6.2.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        }
       }
     },
     "parent-module": {
@@ -2194,9 +2222,9 @@
       "dev": true
     },
     "semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.1.3.tgz",
+      "integrity": "sha512-ekM0zfiA9SCBlsKa2X1hxyxiI4L3B6EbVJkkdgQXnSEEaHlGdvyodMruTiulSRWMMB4NeIuYNMC9rTKTz97GxA=="
     },
     "semver-diff": {
       "version": "3.1.1",
@@ -2204,6 +2232,13 @@
       "integrity": "sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==",
       "requires": {
         "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        }
       }
     },
     "set-blocking": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -168,6 +168,13 @@
         "minimist": "1.2.0",
         "ora": "3.0.0",
         "winston": "2.4.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        }
       }
     },
     "@istanbuljs/load-nyc-config": {
@@ -215,9 +222,9 @@
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
     },
     "acorn": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
-      "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
+      "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
       "dev": true
     },
     "acorn-jsx": {
@@ -1690,9 +1697,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mkdirp": {
       "version": "0.5.1",

--- a/package.json
+++ b/package.json
@@ -30,11 +30,11 @@
     "git-clone": "0.1.0",
     "glob": "7.1.6",
     "latest-version": "5.1.0",
-    "minimist": "1.2.0",
+    "minimist": "^1.2.5",
     "node-forge": "0.9.1",
+    "package-json": "6.5.0",
     "promptly": "3.0.3",
-    "update-notifier": "4.0.0",
-    "package-json": "6.5.0"
+    "update-notifier": "4.0.0"
   },
   "devDependencies": {
     "eslint": "6.8.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "node-forge": "0.9.1",
     "package-json": "6.5.0",
     "promptly": "3.0.3",
+    "semver": "7.1.3",
     "update-notifier": "4.0.0"
   },
   "devDependencies": {

--- a/test/lib-app-dependencies.spec.js
+++ b/test/lib-app-dependencies.spec.js
@@ -20,6 +20,12 @@ describe('App dependencies', () => {
           return '4.5.6';
         case 'from-branch':
           return 'foo/bar#branch';
+        case 'foo':
+          return '11.7.0';
+        case 'bar':
+          return '1.1.3';
+        case 'baz':
+          return '7.5.0';
         default:
           return '9.8.7';
       }
@@ -50,8 +56,13 @@ describe('App dependencies', () => {
   describe('upgradeDependencies() method', () => {
 
     it('should upgrade dependencies', async () => {
+
+      // The utility should respect existing version ranges or convert hard-versions to ranges.
       const dependencies = {
-        '@foo/bar': '12.2.3'
+        '@foo/bar': '12.2.3',
+        'foo': '^11.0.0',
+        'bar': '~1.1.1',
+        'baz': 'latest'
       };
 
       const devDependencies = {
@@ -62,7 +73,10 @@ describe('App dependencies', () => {
       await appDependencies.upgradeDependencies(dependencies);
 
       expect(dependencies).toEqual({
-        '@foo/bar': '12.2.5'
+        '@foo/bar': '12.2.5',
+        'foo': '11.7.0',
+        'bar': '1.1.3',
+        'baz': '7.5.0'
       });
 
       await appDependencies.upgradeDependencies(devDependencies);
@@ -72,19 +86,25 @@ describe('App dependencies', () => {
         'from-branch': 'foo/bar#branch'
       });
 
-      expect(latestVersionMock).toHaveBeenCalledWith(
-        '@foo/bar',
-        {
-          version: '^12.2.3'
-        }
-      );
+      expect(latestVersionMock).toHaveBeenCalledWith('@foo/bar', {
+        version: '^12.2.3'
+      });
 
-      expect(latestVersionMock).toHaveBeenCalledWith(
-        '@foo/baz',
-        {
-          version: '^4.5.6'
-        }
-      );
+      expect(latestVersionMock).toHaveBeenCalledWith('@foo/baz', {
+        version: '^4.5.6'
+      });
+
+      expect(latestVersionMock).toHaveBeenCalledWith('foo', {
+        version: '^11.0.0'
+      });
+
+      expect(latestVersionMock).toHaveBeenCalledWith('bar', {
+        version: '~1.1.1'
+      });
+
+      expect(latestVersionMock).toHaveBeenCalledWith('baz', {
+        version: 'latest'
+      });
     });
 
     it('should handle missing dependencies section', async () => {

--- a/test/lib-app-dependencies.spec.js
+++ b/test/lib-app-dependencies.spec.js
@@ -26,6 +26,8 @@ describe('App dependencies', () => {
           return '1.1.3';
         case 'baz':
           return '7.5.0';
+        case 'sample':
+          return '2.0.1';
         default:
           return '9.8.7';
       }
@@ -62,7 +64,8 @@ describe('App dependencies', () => {
         '@foo/bar': '12.2.3',
         'foo': '^11.0.0',
         'bar': '~1.1.1',
-        'baz': 'latest'
+        'baz': 'latest',
+        'sample': '1 || ^2'
       };
 
       const devDependencies = {
@@ -76,7 +79,8 @@ describe('App dependencies', () => {
         '@foo/bar': '12.2.5',
         'foo': '11.7.0',
         'bar': '1.1.3',
-        'baz': '7.5.0'
+        'baz': '7.5.0',
+        'sample': '2.0.1'
       });
 
       await appDependencies.upgradeDependencies(devDependencies);
@@ -95,15 +99,19 @@ describe('App dependencies', () => {
       });
 
       expect(latestVersionMock).toHaveBeenCalledWith('foo', {
-        version: '^11.0.0'
+        version: '>=11.0.0 <12.0.0'
       });
 
       expect(latestVersionMock).toHaveBeenCalledWith('bar', {
-        version: '~1.1.1'
+        version: '>=1.1.1 <1.2.0'
       });
 
       expect(latestVersionMock).toHaveBeenCalledWith('baz', {
         version: 'latest'
+      });
+
+      expect(latestVersionMock).toHaveBeenCalledWith('sample', {
+        version: '>=1.0.0 <2.0.0||>=2.0.0 <3.0.0'
       });
     });
 

--- a/test/lib-cleanup.spec.js
+++ b/test/lib-cleanup.spec.js
@@ -5,6 +5,10 @@ describe('Cleanup', () => {
   let cleanup;
 
   beforeEach(() => {
+    mock('@blackbaud/skyux-logger', {
+      info() {}
+    });
+
     fsExtraMock = {
       exists: jasmine.createSpy('exists'),
       unlink: jasmine.createSpy('unlink'),


### PR DESCRIPTION
- Add support for installing the preferred versions of `typescript`, `ts-node`, and `zone.js` (this will allow us to enforce specific versions of those packages, instead of relying on the user to find the "best" match).
- Bugfix: allow installing pre-releases versions of peer dependencies (currently only the `latest` versions of the peers are installed).
- Updated/cleaned-up console logs throughout.