### PR TITLE
[rc] Fix `skyux upgrade` invalid versions

### DIFF
--- a/lib/app-dependencies.js
+++ b/lib/app-dependencies.js
@@ -27,22 +27,49 @@ function fixDependencyOrder(dependencies) {
   return dependencies;
 }
 
+function validateDependencies(dependencies) {
+  const validDependencies = {};
+  const invalidDependencies = {};
+
+  for (const packageName in dependencies) {
+    const currentVersion = dependencies[packageName];
+    if (
+      semver.valid(currentVersion) ||
+      semver.validRange(currentVersion) ||
+      // By default, other than latest, no tag has any special significance to npm itself.
+      // See: https://docs.npmjs.com/cli/dist-tag#purpose
+      currentVersion === 'latest'
+    ) {
+      validDependencies[packageName] = currentVersion;
+    } else {
+      invalidDependencies[packageName] = currentVersion;
+    }
+  }
+
+  return {
+    validDependencies,
+    invalidDependencies
+  };
+}
+
 /**
  * Finds all dependencies with a version specified as "latest", looks up the package in the global
  * NPM registry, and replaces it with the actual version number of the latest version of the package.
  * @param {*} dependencies The dependencies with versions to resolve.
  */
 async function setDependencyVersions(dependencies) {
-  const packageNames = Object.keys(dependencies);
+  const { validDependencies } = validateDependencies(dependencies);
+  const packageNames = Object.keys(validDependencies);
 
   const dependencyPromises = packageNames.map(
     packageName => latestVersion(packageName, {
-      version: dependencies[packageName]
+      version: validDependencies[packageName]
     })
   );
 
   const versionNumbers = await Promise.all(dependencyPromises);
 
+  // Update dependency versions.
   packageNames.forEach((packageName, index) => {
     dependencies[packageName] = versionNumbers[index];
   });
@@ -57,12 +84,15 @@ async function addSkyPeerDependencies(dependencies) {
   let foundNewDependency = false;
 
   if (dependencies) {
-    const skyPackageNames = Object.keys(dependencies).filter((packageName) => {
-      return (
-        packageName.indexOf('@skyux/') === 0 ||
-        packageName.indexOf('@blackbaud/skyux-lib-') === 0
-      );
-    });
+    const { validDependencies } = validateDependencies(dependencies);
+
+    const skyPackageNames = Object.keys(validDependencies)
+      .filter((packageName) => {
+        return (
+          packageName.indexOf('@skyux/') === 0 ||
+          packageName.indexOf('@blackbaud/skyux-lib-') === 0
+        );
+      });
 
     const peerPromises = skyPackageNames.map(packageName => {
       const version = dependencies[packageName];
@@ -100,6 +130,7 @@ async function addSkyPeerDependencies(dependencies) {
       }
     }
 
+    /* istanbul ignore else */
     if (ignoredPackages.length) {
       logger.info('Warning: The following missing peer dependencies were not added because they are not known Angular or SKY UX packages. Do you need to install them yourself?');
       logger.info(LOG_SEPARATOR);
@@ -123,12 +154,17 @@ async function addSkyPeerDependencies(dependencies) {
 async function upgradeDependencies(dependencies) {
   if (dependencies) {
 
+    const {
+      validDependencies,
+      invalidDependencies
+    } = validateDependencies(dependencies);
+
     const promises = [];
 
-    for (const packageName in dependencies) {
-      const currentVersion = dependencies[packageName];
-      const validRange = semver.validRange(currentVersion);
+    for (const packageName in validDependencies) {
+      const currentVersion = validDependencies[packageName];
 
+      let validRange;
       let versionRange;
 
       switch (packageName) {
@@ -151,15 +187,16 @@ async function upgradeDependencies(dependencies) {
           );
           break;
         default:
+          validRange = semver.validRange(currentVersion);
           if (validRange === currentVersion) {
             // Convert the specific version into a range.
             versionRange = `^${currentVersion}`;
-          } else if (validRange !== null) {
+          } else if (currentVersion === 'latest') {
+            // Use 'latest' dist-tag.
+            versionRange = currentVersion;
+          } else {
             // Use the validated range.
             versionRange = validRange;
-          } else {
-            // Current version specifies a dist-tag or git URL.
-            versionRange = currentVersion;
           }
 
           logger.info(`Finding latest version within range ${packageName}@${versionRange}...`);
@@ -178,14 +215,18 @@ async function upgradeDependencies(dependencies) {
     const updateMessages = [];
     const ignoreMessages = [];
 
-    Object.keys(dependencies).forEach((packageName, index) => {
+    Object.keys(validDependencies).forEach((packageName, index) => {
       const versionNumber = versionNumbers[index];
-      if (dependencies[packageName] === versionNumber) {
+
+      // Update the dependency version.
+      dependencies[packageName] = versionNumber;
+
+      // Add logger messages.
+      if (validDependencies[packageName] === versionNumber) {
         ignoreMessages.push(`Skipped package ${packageName} because it is already set to (${versionNumber}).`);
       } else {
         updateMessages.push(`Updated package ${packageName} to (${versionNumber}).`);
       }
-      dependencies[packageName] = versionNumber;
     });
 
     if (ignoreMessages.length) {
@@ -198,11 +239,22 @@ async function upgradeDependencies(dependencies) {
       logger.info(LOG_SEPARATOR);
     }
 
-    logger.info(`Total packages upgraded: ${updateMessages.length}`);
-    logger.info(LOG_SEPARATOR);
-  }
+    const invalidPackages = Object.keys(invalidDependencies);
+    if (invalidPackages.length) {
+      invalidPackages.forEach((packageName) => {
+        const version = invalidDependencies[packageName];
+        logger.warn(`Warning: Skipped package ${packageName} because it did not provide a valid version or range: "${version}".`);
+      });
+      logger.info(LOG_SEPARATOR);
+    }
 
-  fixDependencyOrder(dependencies);
+    logger.info(`Total packages upgraded: ${updateMessages.length}`);
+    logger.info(`Total packages skipped: ${invalidPackages.length}`);
+
+    logger.info(LOG_SEPARATOR);
+
+    return fixDependencyOrder(dependencies);
+  }
 }
 
 module.exports = {

--- a/lib/upgrade.js
+++ b/lib/upgrade.js
@@ -8,17 +8,25 @@ async function upgrade() {
 
   const packageJson = await jsonUtils.readJson('package.json');
 
-  await appDependencies.upgradeDependencies(packageJson.dependencies);
-  await appDependencies.upgradeDependencies(packageJson.devDependencies);
+  try {
+    logger.info('Upgrading dependencies...');
+    await appDependencies.upgradeDependencies(packageJson.dependencies);
 
-  await appDependencies.addSkyPeerDependencies(packageJson.dependencies);
-  await appDependencies.addSkyPeerDependencies(packageJson.devDependencies);
+    logger.info('Upgrading development dependencies...');
+    await appDependencies.upgradeDependencies(packageJson.devDependencies);
 
-  await jsonUtils.writeJson('package.json', packageJson);
+    logger.info('Checking SKY UX peer dependencies...');
+    await appDependencies.addSkyPeerDependencies(packageJson.dependencies);
+    await appDependencies.addSkyPeerDependencies(packageJson.devDependencies);
 
-  await cleanup.deleteDependencies();
+    await jsonUtils.writeJson('package.json', packageJson);
 
-  logger.info('Done.');
+    await cleanup.deleteDependencies();
+
+    logger.info('Done.');
+  } catch (error) {
+    logger.error('Error: ' + error.message);
+  }
 }
 
 module.exports = upgrade;

--- a/test/lib-app-dependencies.spec.js
+++ b/test/lib-app-dependencies.spec.js
@@ -9,7 +9,9 @@ describe('App dependencies', () => {
 
   beforeEach(() => {
     loggerMock = {
-      info() {}
+      error() {},
+      info() {},
+      warn() {}
     };
 
     latestVersionMock = jasmine.createSpy('latestVersion').and.callFake((packageName) => {
@@ -113,6 +115,10 @@ describe('App dependencies', () => {
       expect(latestVersionMock).toHaveBeenCalledWith('sample', {
         version: '>=1.0.0 <2.0.0||>=2.0.0 <3.0.0'
       });
+
+      expect(latestVersionMock).not.toHaveBeenCalledWith('from-branch', {
+        version: 'foo/bar#branch'
+      });
     });
 
     it('should handle missing dependencies section', async () => {
@@ -168,6 +174,63 @@ describe('App dependencies', () => {
         {
           version: 'latest'
         }
+      );
+    });
+
+    it('should use a specific range for TypeScript', async () => {
+      const loggerSpy = spyOn(loggerMock, 'info').and.callThrough();
+
+      await appDependencies.upgradeDependencies({
+        'typescript': '2.1.0'
+      });
+
+      expect(latestVersionMock).toHaveBeenCalledWith(
+        'typescript',
+        {
+          version: '~3.6.4'
+        }
+      );
+
+      expect(loggerSpy).toHaveBeenCalledWith(
+        jasmine.stringMatching(/because TypeScript does not support semantic versioning/)
+      );
+    });
+
+    it('should use a specific range for zone.js', async () => {
+      const loggerSpy = spyOn(loggerMock, 'info').and.callThrough();
+
+      await appDependencies.upgradeDependencies({
+        'zone.js': '1.1.0'
+      });
+
+      expect(latestVersionMock).toHaveBeenCalledWith(
+        'zone.js',
+        {
+          version: '~0.10.2'
+        }
+      );
+
+      expect(loggerSpy).toHaveBeenCalledWith(
+        jasmine.stringMatching(/because Angular requires a specific minor version/)
+      );
+    });
+
+    it('should use a specific range for ts-node', async () => {
+      const loggerSpy = spyOn(loggerMock, 'info').and.callThrough();
+
+      await appDependencies.upgradeDependencies({
+        'ts-node': '1.0.0'
+      });
+
+      expect(latestVersionMock).toHaveBeenCalledWith(
+        'ts-node',
+        {
+          version: '~8.6.0'
+        }
+      );
+
+      expect(loggerSpy).toHaveBeenCalledWith(
+        jasmine.stringMatching(/because Angular requires a specific minor version/)
       );
     });
 

--- a/test/lib-upgrade.spec.js
+++ b/test/lib-upgrade.spec.js
@@ -1,44 +1,38 @@
 const mock = require('mock-require');
 
 describe('Upgrade', () => {
+  let appDependenciesMock;
   let jsonUtilsMock;
   let loggerMock;
-  let latestVersionMock;
   let cleanupMock;
   let upgrade;
 
   beforeEach(() => {
+    appDependenciesMock = {
+      async addSkyPeerDependencies() {},
+      async upgradeDependencies() {}
+    };
+
     jsonUtilsMock = {
       readJson: jasmine.createSpy('readJson'),
       writeJson: jasmine.createSpy('writeJson')
     };
 
     loggerMock = {
+      error() {},
       info: jasmine.createSpy('info')
     };
-
-    latestVersionMock = jasmine.createSpy('latestVersion').and.callFake((packageName, options) => {
-      switch (packageName) {
-        case '@foo/bar':
-          return '12.2.5';
-        case '@foo/baz':
-          return '4.5.6';
-        default:
-          return options.version;
-      }
-    });
 
     cleanupMock = {
       deleteDependencies: jasmine.createSpy('deleteDependencies')
     };
 
     mock('@blackbaud/skyux-logger', loggerMock);
-    mock('latest-version', latestVersionMock);
 
     mock('../lib/utils/json-utils', jsonUtilsMock);
+    mock('../lib/app-dependencies', appDependenciesMock);
     mock('../lib/cleanup', cleanupMock);
 
-    mock.reRequire('../lib/app-dependencies');
     upgrade = mock.reRequire('../lib/upgrade');
   });
 
@@ -46,141 +40,55 @@ describe('Upgrade', () => {
     mock.stopAll();
   });
 
-  it('should upgrade an application', async () => {
+  it('should upgrade an application', async (done) => {
+    const upgradeDependenciesSpy = spyOn(appDependenciesMock, 'upgradeDependencies').and.callThrough();
+    const skyDependenciesSpy = spyOn(appDependenciesMock, 'addSkyPeerDependencies').and.callThrough();
+
+    const dependencies = {
+      '@foo/bar': '12.2.3'
+    };
+
+    const devDependencies = {
+      '@foo/baz': '4.5.6',
+      'from-branch': 'foo/bar#branch'
+    };
+
     jsonUtilsMock.readJson.and.returnValue({
-      dependencies: {
-        '@foo/bar': '12.2.3'
-      },
-      devDependencies: {
-        '@foo/baz': '4.5.6',
-        'from-branch': 'foo/bar#branch'
-      }
+      dependencies,
+      devDependencies
     });
 
     await upgrade();
 
-    expect(latestVersionMock).toHaveBeenCalledWith(
-      '@foo/bar',
-      {
-        version: '^12.2.3'
-      }
-    );
-
-    expect(latestVersionMock).toHaveBeenCalledWith(
-      '@foo/baz',
-      {
-        version: '^4.5.6'
-      }
-    );
-
-    expect(jsonUtilsMock.writeJson).toHaveBeenCalledWith(
-      'package.json',
-      {
-        dependencies: {
-          '@foo/bar': '12.2.5'
-        },
-        devDependencies: {
-          '@foo/baz': '4.5.6',
-          'from-branch': 'foo/bar#branch'
-        }
-      }
-    );
-
+    expect(upgradeDependenciesSpy).toHaveBeenCalledWith(dependencies);
+    expect(upgradeDependenciesSpy).toHaveBeenCalledWith(devDependencies);
+    expect(skyDependenciesSpy).toHaveBeenCalledWith(dependencies);
+    expect(skyDependenciesSpy).toHaveBeenCalledWith(devDependencies);
+    expect(jsonUtilsMock.writeJson).toHaveBeenCalledWith('package.json', {
+      dependencies,
+      devDependencies
+    });
     expect(cleanupMock.deleteDependencies).toHaveBeenCalled();
+
+    done();
   });
 
-  it('should use a specific range for TypeScript', async () => {
+  it('should handle errors', async (done) => {
+    spyOn(appDependenciesMock, 'upgradeDependencies').and.throwError(
+      'Something bad happened.'
+    );
+
     jsonUtilsMock.readJson.and.returnValue({
-      devDependencies: {
-        'typescript': '2.1'
-      }
+      dependencies: {},
+      devDependencies: {}
     });
+
+    const loggerSpy = spyOn(loggerMock, 'error').and.callThrough();
 
     await upgrade();
 
-    expect(jsonUtilsMock.writeJson).toHaveBeenCalledWith(
-      'package.json',
-      {
-        devDependencies: {
-          'typescript': '~3.6.4'
-        }
-      }
-    );
+    expect(loggerSpy).toHaveBeenCalledWith('Error: Something bad happened.');
 
-    expect(loggerMock.info).toHaveBeenCalledWith(
-      jasmine.stringMatching(/because TypeScript does not support semantic versioning/)
-    );
-  });
-
-  it('should use a specific range for zone.js', async () => {
-    jsonUtilsMock.readJson.and.returnValue({
-      dependencies: {
-        'zone.js': '0.8.29'
-      }
-    });
-
-    await upgrade();
-
-    expect(jsonUtilsMock.writeJson).toHaveBeenCalledWith(
-      'package.json',
-      {
-        dependencies: {
-          'zone.js': '~0.10.2'
-        }
-      }
-    );
-
-    expect(loggerMock.info).toHaveBeenCalledWith(
-      jasmine.stringMatching(/because Angular requires a specific minor version/)
-    );
-  });
-
-  it('should use a specific range for ts-node', async () => {
-    jsonUtilsMock.readJson.and.returnValue({
-      dependencies: {
-        'ts-node': '1.2.0'
-      }
-    });
-
-    await upgrade();
-
-    expect(jsonUtilsMock.writeJson).toHaveBeenCalledWith(
-      'package.json',
-      {
-        dependencies: {
-          'ts-node': '~8.6.0'
-        }
-      }
-    );
-
-    expect(loggerMock.info).toHaveBeenCalledWith(
-      jasmine.stringMatching(/because Angular requires a specific minor version/)
-    );
-  });
-
-  it('should handle missing dependency section', async () => {
-    jsonUtilsMock.readJson.and.returnValue({
-      devDependencies: {
-        '@foo/bar': '12.2.3'
-      }
-    });
-
-    await upgrade();
-
-    expect(latestVersionMock).toHaveBeenCalledWith(
-      '@foo/bar',
-      {
-        version: '^12.2.3'
-      }
-    );
-
-    expect(jsonUtilsMock.writeJson).toHaveBeenCalledWith(
-      'package.json',
-      {
-        devDependencies: {
-          '@foo/bar': '12.2.5'
-        }
-      }
-    );
+    done();
   });
 });


### PR DESCRIPTION
- `skyux upgrade` now fails with GitHub branches, or dist-tags (such as "latest") due to the usage of the NPM package `semver`. This was an oversight on my part with the previous pull request.