### PR TITLE
`skyux new` > Use 3.x.x branch

### DIFF
--- a/lib/utils/clone.js
+++ b/lib/utils/clone.js
@@ -2,7 +2,7 @@ const gitClone = require('git-clone');
 const logger = require('@blackbaud/skyux-logger');
 
 async function clone(url, target, argv) {
-  const checkout = argv.checkout || 'master';
+  const checkout = argv.checkout || '3.x.x';
   logger.info(`Cloning ${url}#${checkout} into ${target}`);
 
   return new Promise((resolve, reject) => {

--- a/test/lib-utils-clone.spec.js
+++ b/test/lib-utils-clone.spec.js
@@ -23,7 +23,7 @@ describe('clone utility', () => {
   it('should pass the url, target, and default branch of master to git-clone', async (done) => {
     const url = 'my-url';
     const target = 'my-target';
-    const checkout = 'master';
+    const checkout = '3.x.x';
 
     spyGitClone.and.callFake((a, b, c, callback) => {
       expect(logger.info).toHaveBeenCalledWith(`Cloning ${url}#${checkout} into ${target}`);


### PR DESCRIPTION
Running `skyux new` will use the `3.x.x` branch of the template, instead of the `master` branch.
(SKY UX 4 will use the `master` branch of the template.)