### PR TITLE
[rc] Use correct version of Builder in `skyux migrate`

### DIFF
--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -98,6 +98,11 @@ async function adjustPackageJson() {
   packageJson = await pact.validateDependencies(packageJson);
   packageJson = skyuxLibraries.validatePackageJson(packageJson);
 
+  // Update the version of Builder so that the upgrade command uses the correct version ranges.
+  if (packageJson.devDependencies) {
+    packageJson.devDependencies['@skyux-sdk/builder'] = '^4.0.0-rc.0';
+  }
+
   // Remove the engines property since it is not used by our pipelines.
   delete packageJson.engines;
 

--- a/lib/upgrade.js
+++ b/lib/upgrade.js
@@ -15,10 +15,10 @@ async function getAppDependenciesUtil(packageJson) {
 
   const majorVersion = builderVersionInstalled.split('.')[0];
   switch (majorVersion) {
-    case '4':
-      return require('./app-dependencies');
-    default:
+    case '3':
       return require('./v3-compat/app-dependencies');
+    default:
+      return require('./app-dependencies');
   }
 }
 

--- a/test/lib-migrate.spec.js
+++ b/test/lib-migrate.spec.js
@@ -70,6 +70,7 @@ describe('Migrate', function () {
         '@blackbaud/skyux-lib-help': '*',
         '@blackbaud/skyux-lib-testing': '*',
         '@skyux-sdk/builder-plugin-pact': '*',
+        '@skyux-sdk/builder': '*',
         '@skyux-sdk/pact': '*',
         'bar': '*'
       },
@@ -89,6 +90,7 @@ describe('Migrate', function () {
         'foo': '*'
       },
       devDependencies: {
+        '@skyux-sdk/builder': '^4.0.0-rc.0',
         'bar': '*'
       },
       peerDependencies: {
@@ -108,6 +110,23 @@ describe('Migrate', function () {
     const migrate = mock.reRequire('../lib/migrate');
     await migrate({});
     expect(writeSpy).toHaveBeenCalledWith('package.json', {});
+    done();
+  });
+
+  it('should upgrade the version of `@skyux-sdk/builder` in package.json', async (done) => {
+    spyOn(jsonUtilsMock, 'readJson').and.returnValue({
+      devDependencies: {
+        '@skyux-sdk/builder': '3.0.0'
+      }
+    });
+    const writeSpy = spyOn(jsonUtilsMock, 'writeJson').and.callThrough();
+    const migrate = mock.reRequire('../lib/migrate');
+    await migrate({});
+    expect(writeSpy).toHaveBeenCalledWith('package.json', {
+      devDependencies: {
+        '@skyux-sdk/builder': '^4.0.0-rc.0'
+      }
+    });
     done();
   });
 


### PR DESCRIPTION
`skyux migrate` runs `skyux upgrade` after the migration. However, we didn't update the version of Builder before running the upgrade, so it was using the backwards-compatible utility, instead of the new one.