### PR TITLE
`skyux migrate` > Remove `@skyux-sdk/cli` and `tslib` from devDependencies

### DIFF
--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -61,6 +61,10 @@ function validateDependencies(packageJson) {
     {
       name: /^rxjs-compat$/,
       reason: 'SKY UX libraries support the latest version of rxjs'
+    },
+    {
+      name: /^tslib$/,
+      reason: 'it is a dependency of @skyux-sdk/builder'
     }
   ];
 

--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -39,7 +39,7 @@ function validateDependencies(packageJson) {
       reason: ''
     },
     {
-      name: /^@skyux-sdk\/(builder-plugin-pact|pact)$/,
+      name: /^@skyux-sdk\/(builder-plugin-pact|pact|cli)$/,
       reason: ''
     },
     {

--- a/test/lib-migrate.spec.js
+++ b/test/lib-migrate.spec.js
@@ -62,7 +62,8 @@ describe('Migrate', function () {
         'core-js': '*',
         'intl-tel-input': '*',
         'microedge-rxstate': '*',
-        'foo': '*'
+        'foo': '*',
+        'tslib': '*'
       },
       devDependencies: {
         '@angular/http': '*',

--- a/test/lib-migrate.spec.js
+++ b/test/lib-migrate.spec.js
@@ -71,6 +71,7 @@ describe('Migrate', function () {
         '@blackbaud/skyux-lib-testing': '*',
         '@skyux-sdk/builder-plugin-pact': '*',
         '@skyux-sdk/builder': '*',
+        '@skyux-sdk/cli': '*',
         '@skyux-sdk/pact': '*',
         'bar': '*'
       },


### PR DESCRIPTION
For some reason, some of our consumers' SPAs have listed `@skyux-sdk/cli` in their development dependencies; this will remove it during the `skyux migrate` command.