### PR TITLE
Checkout the correct branch from the SPA's repo

### DIFF
--- a/lib/new.js
+++ b/lib/new.js
@@ -172,7 +172,7 @@ async function cloneTemplate(argv) {
   const message = logger.promise(`Cloning ${settings.template.name} SKY UX template.`);
 
   try {
-    await clone(settings.template.url, settings.pathTmp, argv);
+    await clone(settings.template.url, settings.pathTmp, (argv && argv.checkout) || '4.x.x');
     message.succeed(`${settings.template.name} template successfully cloned.`);
   } catch (err) {
 
@@ -193,11 +193,11 @@ async function cloneTemplate(argv) {
  * Clones the repo into the specified path
  * @name cloneRepo
  */
-async function cloneRepo(argv) {
+async function cloneRepo() {
   const message = logger.promise('Cloning your repository.');
 
   try {
-    await clone(settings.url, settings.path, argv);
+    await clone(settings.url, settings.path, 'master');
 
     if (isRepoEmpty(settings.path)) {
       message.succeed();
@@ -333,7 +333,7 @@ async function skyuxNew(argv) {
     settings.url = repoUrl;
 
     if (settings.url) {
-      await cloneRepo(argv);
+      await cloneRepo();
     }
 
     await cloneTemplate(argv);

--- a/lib/utils/clone.js
+++ b/lib/utils/clone.js
@@ -1,8 +1,7 @@
 const gitClone = require('git-clone');
 const logger = require('@blackbaud/skyux-logger');
 
-async function clone(url, target, argv) {
-  const checkout = argv.checkout || '4.x.x';
+async function clone(url, target, checkout) {
   logger.info(`Cloning ${url}#${checkout} into ${target}`);
 
   return new Promise((resolve, reject) => {

--- a/test/lib-new.spec.js
+++ b/test/lib-new.spec.js
@@ -171,6 +171,14 @@ describe('skyux new command', () => {
       expect(spies.spyLogger.error).toHaveBeenCalledWith(error);
     });
 
+    it('should checkout the repo\'s master branch', async () => {
+      const repo = 'https://example.com/custom-repo.git';
+      const spies = getSpies('name', repo);
+      spies.spyClone.and.returnValue(Promise.resolve());
+      await getLib()({});
+      expect(expect(spies.spyClone.calls.argsFor(0)[2]).toBe('master'));
+    });
+
     it('should handle a non-empty repo when cloning', async () => {
       const repo = 'https://example.com/custom-repo.git';
       const spies = getSpies('name', repo);
@@ -237,6 +245,13 @@ describe('skyux new command', () => {
       expect(spies.spyLoggerPromise.succeed).toHaveBeenCalledWith(
         `${template} template successfully cloned.`
       );
+    });
+
+    it('should checkout the repo\'s 4.x.x branch', async () => {
+      const spies = getSpies('name', '');
+      spies.spyClone.and.returnValue(Promise.resolve());
+      await getLib()({});
+      expect(expect(spies.spyClone.calls.argsFor(0)[2]).toBe('4.x.x'));
     });
 
     it('should handle an error cloning a template because of url', async () => {

--- a/test/lib-utils-clone.spec.js
+++ b/test/lib-utils-clone.spec.js
@@ -24,23 +24,6 @@ describe('clone utility', () => {
     mock.stopAll();
   });
 
-  it('should pass the url, target, and default branch of master to git-clone', async (done) => {
-    const url = 'my-url';
-    const target = 'my-target';
-    const checkout = '4.x.x';
-
-    spyGitClone.and.callFake((a, b, c, callback) => {
-      expect(logger.info).toHaveBeenCalledWith(`Cloning ${url}#${checkout} into ${target}`);
-      expect(url).toEqual(a);
-      expect(target).toEqual(b);
-      expect({ checkout }).toEqual(c);
-      callback();
-    });
-
-    await clone(url, target, {});
-    done();
-  });
-
   it('should pass the url, target, and specified branch to git-clone', async (done) => {
     const url = 'my-url';
     const target = 'my-target';
@@ -54,7 +37,7 @@ describe('clone utility', () => {
       callback();
     });
 
-    await clone(url, target, { checkout });
+    await clone(url, target, checkout);
     done();
   });
 
@@ -65,7 +48,7 @@ describe('clone utility', () => {
     });
 
     try {
-      await clone('', '', {});
+      await clone('', '', '4.x.x');
     } catch (errThrown) {
       expect(errThrown).toEqual({
         message: err,


### PR DESCRIPTION
PR #87 introduced a bug where the `4.x.x` branch was checked out not only when the template repo was cloned, but when cloning the SPA repo supplied when `skyux new` is called, causing an error.