### PR TITLE
Fix Pact config migration, package vulnerabilities

### DIFF
--- a/lib/utils/pact.js
+++ b/lib/utils/pact.js
@@ -50,7 +50,39 @@ async function configExists() {
   return enablePact;
 }
 
+async function validateConfig() {
+  const hasPactConfig = await configExists();
+  if (!hasPactConfig) {
+    return;
+  }
+
+  // Make sure a skyuxconfig.pact.json file exists.
+  const fileExists = await fs.pathExists('skyuxconfig.pact.json');
+  if (!fileExists) {
+    await jsonUtils.writeJson('skyuxconfig.pact.json', {});
+  }
+
+  const skyuxConfig = await jsonUtils.readJson('skyuxconfig.json');
+  const skyuxPactConfig = await jsonUtils.readJson('skyuxconfig.pact.json');
+
+  // Move `pacts` from skyuxconfig.json to skyuxconfig.pact.json.
+  if (skyuxConfig.pacts) {
+    skyuxPactConfig.pacts = skyuxConfig.pacts;
+    delete skyuxConfig.pacts;
+  }
+
+  // Add Pact Builder plugin.
+  skyuxPactConfig.plugins = skyuxPactConfig.plugins || [];
+  /* istanbul ignore else */
+  if (skyuxPactConfig.plugins.indexOf('@skyux-sdk/builder-plugin-pact') === -1) {
+    skyuxPactConfig.plugins.push('@skyux-sdk/builder-plugin-pact');
+  }
+
+  await jsonUtils.writeJson('skyuxconfig.json', skyuxConfig);
+  await jsonUtils.writeJson('skyuxconfig.pact.json', skyuxPactConfig);
+}
+
 module.exports = {
-  configExists,
+  validateConfig,
   validateDependencies
 };

--- a/lib/utils/skyux-config.js
+++ b/lib/utils/skyux-config.js
@@ -10,12 +10,13 @@ async function validateSkyUxConfigJson() {
 
   logger.info('Validating SKY UX config...');
 
+  await pact.validateConfig();
+
   const configFiles = ['skyuxconfig.json'].concat(glob.sync('skyuxconfig.*.json'));
   const readPromises = configFiles.map((file) => {
     return jsonUtils.readJson(file);
   });
 
-  const hasPactConfig = await pact.configExists();
   const contents = await Promise.all(readPromises);
 
   contents.forEach((skyuxJson, i) => {
@@ -48,15 +49,6 @@ async function validateSkyUxConfigJson() {
         skyuxJson.host.frameOptions = {
           none: true
         };
-      }
-
-      // Add Pact Builder plugin.
-      if (hasPactConfig) {
-        skyuxJson.plugins = skyuxJson.plugins || [];
-        /* istanbul ignore else */
-        if (skyuxJson.plugins.indexOf('@skyux-sdk/builder-plugin-pact') === -1) {
-          skyuxJson.plugins.push('@skyux-sdk/builder-plugin-pact');
-        }
       }
     }
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1735,9 +1735,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
       "dev": true
     },
     "lodash.flattendeep": {

--- a/test/lib-utils-skyux-config.spec.js
+++ b/test/lib-utils-skyux-config.spec.js
@@ -26,7 +26,7 @@ describe('SKY UX Config util', function () {
     };
 
     pactMock = {
-      configExists: () => Promise.resolve(false)
+      validateConfig: () => Promise.resolve()
     };
 
     mock('@blackbaud/skyux-logger', loggerMock);
@@ -120,43 +120,6 @@ describe('SKY UX Config util', function () {
         foo: 'bar'
       }
     });
-  });
-
-  it('should add pact plugin', async () => {
-    testSkyUxConfigJson = {};
-
-    spyOn(pactMock, 'configExists').and.returnValue(Promise.resolve(true));
-
-    const util = mock.reRequire('../lib/utils/skyux-config');
-    const writeSpy = spyOn(jsonUtilsMock, 'writeJson').and.callThrough();
-
-    await util.validateSkyUxConfigJson();
-
-    const config = writeSpy.calls.allArgs()[0][1];
-    expect(config.plugins).toEqual([
-      '@skyux-sdk/builder-plugin-pact'
-    ]);
-  });
-
-  it('should add pact plugin and leave other plugins untouched', async () => {
-    testSkyUxConfigJson = {
-      plugins: [
-        '@foo/bar'
-      ]
-    };
-
-    spyOn(pactMock, 'configExists').and.returnValue(Promise.resolve(true));
-
-    const util = mock.reRequire('../lib/utils/skyux-config');
-    const writeSpy = spyOn(jsonUtilsMock, 'writeJson').and.callThrough();
-
-    await util.validateSkyUxConfigJson();
-
-    const config = writeSpy.calls.allArgs()[0][1];
-    expect(config.plugins).toEqual([
-      '@foo/bar',
-      '@skyux-sdk/builder-plugin-pact'
-    ]);
   });
 
   it('should remove deprecated properties', async () => {


### PR DESCRIPTION
The migration utility adds the `@skyux-sdk/builder-plugin-pact` plugin to the `skyuxconfig.json` file, but it should be added to the `skyuxconfig.pact.json` file, to prevent it from setting `BBAuth.mock = true` in the production app.