### PR TITLE
Eject > Install builder after library generated

### DIFF
--- a/lib/app-dependencies.js
+++ b/lib/app-dependencies.js
@@ -233,6 +233,10 @@ async function upgradeDependencies(dependencies) {
         version: '^4.0.0'
       },
       {
+        name: '@blackbaud-internal/skyux-angular-builders',
+        version: '^5.0.0-alpha.0'
+      },
+      {
         regexp: /^@skyux\/(?!auth-client-factory)/,
         version: '^4.0.0-rc.0'
       },
@@ -243,6 +247,10 @@ async function upgradeDependencies(dependencies) {
       {
         regexp: /^@skyux-sdk\/builder-plugin-(pact|skyux)$/,
         version: '^4.0.0-rc.0'
+      },
+      {
+        name: '@skyux-sdk/angular-builders',
+        version: '^5.0.0-alpha.0'
       },
       {
         name: '@skyux-sdk/builder-plugin-stache',

--- a/lib/eject.js
+++ b/lib/eject.js
@@ -395,7 +395,6 @@ async function eject() {
 
     logger.info('Done ejecting Angular CLI application.');
   } catch (err) {
-    console.error(err);
     logger.error(`[skyux eject] Error: ${err.message}`);
     process.exit(1);
   }

--- a/lib/eject.js
+++ b/lib/eject.js
@@ -381,10 +381,6 @@ async function eject() {
     deprecateFiles(ejectedProjectPath);
     createSkyPagesModule(ejectedProjectPath, routes);
 
-    // Add the SKY UX Angular builder and update SKY UX dependencies.
-    addSkyUxAngularBuilder(ejectedProjectPath, isInternal);
-    await modifyPackageJson(ejectedProjectPath);
-
     // Migrate library source code, if it exists.
     if (isLibrary) {
       const libraryName = migrateLibraries.getName();
@@ -392,6 +388,10 @@ async function eject() {
       migrateLibraries.copyFiles(libraryPath, ejectedProjectPath, libraryName);
       migrateLibraries.modifyPackageJson(ejectedProjectPath, libraryName);
     }
+
+    // Add the SKY UX Angular builder and update SKY UX dependencies.
+    addSkyUxAngularBuilder(ejectedProjectPath, isInternal);
+    await modifyPackageJson(ejectedProjectPath);
 
     logger.info('Done ejecting Angular CLI application.');
   } catch (err) {

--- a/test/lib-app-dependencies.spec.js
+++ b/test/lib-app-dependencies.spec.js
@@ -287,7 +287,8 @@ describe('App dependencies', () => {
 
     it('should use specific ranges for SKY UX and Angular packages', async () => {
       // Dependencies purposefully listed out of order:
-      await appDependencies.upgradeDependencies({
+      const dependencies = {
+        '@blackbaud-internal/skyux-angular-builders': '5.0.1',
         '@skyux-sdk/builder-plugin-skyux': '0.0.1',
         '@blackbaud/skyux-lib-stache': '0.0.1',
         '@blackbaud/skyux-lib-code-block': '0.0.1',
@@ -301,16 +302,21 @@ describe('App dependencies', () => {
         '@skyux-sdk/e2e': '0.0.1',
         '@skyux-sdk/pact': '0.0.1',
         '@blackbaud/skyux-lib-clipboard': '0.0.1',
-        '@skyux-sdk/builder-plugin-pact': '0.0.1'
-      });
+        '@skyux-sdk/builder-plugin-pact': '0.0.1',
+        '@skyux-sdk/angular-builders': '5.0.0'
+      };
+
+      await appDependencies.upgradeDependencies(dependencies);
 
       expect(latestVersionMock.calls.allArgs()).toEqual([
         [ '@angular/common', { version: '^11.0.0' } ],
+        [ '@blackbaud-internal/skyux-angular-builders', { version: '^5.0.0-alpha.0' } ],
         [ '@blackbaud/skyux-lib-clipboard', { version: '^4.0.0' } ],
         [ '@blackbaud/skyux-lib-code-block', { version: '^4.0.0' } ],
         [ '@blackbaud/skyux-lib-media', { version: '^4.0.0' } ],
         [ '@blackbaud/skyux-lib-restricted-view', { version: '^4.0.0' } ],
         [ '@blackbaud/skyux-lib-stache', { version: '^4.0.0' } ],
+        [ '@skyux-sdk/angular-builders', { version: '^5.0.0-alpha.0' } ],
         [ '@skyux-sdk/builder-plugin-pact', { version: '^4.0.0-rc.0' } ],
         [ '@skyux-sdk/builder-plugin-skyux', { version: '^4.0.0-rc.0' } ],
         [ '@skyux-sdk/builder-plugin-stache', { version: '^2.0.0' } ],


### PR DESCRIPTION
We need to install the builder after the library is generated so that the builder's `ng-add` schematic can take effect.