### PR TITLE
Remove type declaration from route param properties

### DIFF
--- a/lib/utils/routes-generator.js
+++ b/lib/utils/routes-generator.js
@@ -236,7 +236,7 @@ function getIndexComponentSource(indexComponent) {
     let paramsConstructors = [];
 
     routeParams.sort().forEach(param => {
-      paramsProperties.push(`public ${param}: string = '';`);
+      paramsProperties.push(`public ${param} = '';`);
       paramsConstructors.push(`this.${param} = params.${param};`);
     });
 


### PR DESCRIPTION
Fixes `no-inferrable-types` TSLint violation